### PR TITLE
Add session renaming and auto title generation

### DIFF
--- a/lib/ai/title-generator.ts
+++ b/lib/ai/title-generator.ts
@@ -1,0 +1,60 @@
+import { generateText } from "ai";
+import { getUtilityModel } from "@/lib/ai/providers";
+import { updateSession } from "@/lib/db/queries";
+
+const MAX_PROMPT_SNIPPET = 400;
+const MAX_TITLE_LENGTH = 80;
+
+function buildPrompt(firstMessage: string): string {
+  const snippet = firstMessage.trim().slice(0, MAX_PROMPT_SNIPPET);
+  return [
+    "You are naming a chat session.",
+    "Generate a concise, descriptive 3-5 word title for the conversation that starts with the message below.",
+    "Do not include quotes or punctuation at the ends. Respond with the title only.",
+    "",
+    `Message: ${snippet}`,
+  ].join("\n");
+}
+
+function sanitizeTitle(raw: string | null | undefined): string | null {
+  if (!raw) {
+    return null;
+  }
+
+  const firstLine = raw
+    .replace(/["“”]/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!firstLine) {
+    return null;
+  }
+
+  const title = firstLine.replace(/\.$/, "");
+  return title ? title.slice(0, MAX_TITLE_LENGTH) : null;
+}
+
+export async function generateSessionTitle(sessionId: string, firstMessageContent: string): Promise<void> {
+  if (!firstMessageContent?.trim()) {
+    return;
+  }
+
+  try {
+    const { text } = await generateText({
+      model: getUtilityModel(),
+      prompt: buildPrompt(firstMessageContent),
+      temperature: 0.4,
+      maxOutputTokens: 60,
+    });
+
+    const title = sanitizeTitle(text);
+    if (!title) {
+      return;
+    }
+
+    await updateSession(sessionId, { title });
+  } catch (error) {
+    console.error(`[Title Generator] Failed to auto-name session ${sessionId}:`, error);
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -864,7 +864,11 @@
       "startNew": "Start new chat",
       "new": "New",
       "empty": "No chat history yet",
-      "delete": "Delete chat"
+      "delete": "Delete chat",
+      "rename": "Rename chat",
+      "edit": "Edit title",
+      "save": "Save",
+      "cancel": "Cancel"
     },
     "session": {
       "untitled": "Untitled chat",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -851,7 +851,11 @@
       "startNew": "Yeni sohbet başlat",
       "new": "Yeni",
       "empty": "Henüz sohbet geçmişi yok",
-      "delete": "Sohbeti sil"
+      "delete": "Sohbeti sil",
+      "rename": "Sohbeti yeniden adlandır",
+      "edit": "Başlığı düzenle",
+      "save": "Kaydet",
+      "cancel": "İptal"
     },
     "session": {
       "untitled": "Başlıksız sohbet",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sessions are now automatically titled based on initial message content.
  * Users can rename sessions directly in the sidebar with inline editing (Enter to save, Escape to cancel).
  * Sessions reorder by last activity timestamp, which updates when new messages appear.
  * Session management controls (rename and delete) appear on hover for easier access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->