### PR TITLE
Fix Telegram Chat API connection failure in Electron production

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
Resolves ECONNREFUSED errors when Telegram messages trigger chat API calls.

Root cause: Chat API endpoint was hardcoded to port 3000, but Electron production runs Next.js standalone server on port 3456.

Changes:
- Added getChatApiBaseUrl() to detect Electron production vs development
- Uses port 3456 in production, 3000 in development
- Added retry logic (3 attempts with exponential backoff)
- Enhanced error logging with connection details
- Properly propagates errors to task registry (no silent failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API communication reliability with automatic retry logic that gracefully handles transient server errors and temporary network issues. Enhanced error handling with improved timeout management and comprehensive diagnostic logging to provide better transparency during API interactions.

* **Chores**
  * Updated build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->