### PR TITLE
Fix Claude/Antigravity MCP tool calls and add ephemeral results

### DIFF
--- a/components/assistant-ui/tool-fallback.tsx
+++ b/components/assistant-ui/tool-fallback.tsx
@@ -442,6 +442,22 @@ const ToolResultDisplay: FC<{ toolName: string; result: ToolResult }> = memo(({ 
     );
   }
 
+  // Fallback for generic text/content results (e.g., MCP tools like take_snapshot)
+  const textContent = result.text || (result as { content?: string }).content;
+  if (textContent && typeof textContent === "string") {
+    // Truncate very long results for display (full result is still available to AI)
+    const displayText = textContent.length > 2000
+      ? textContent.substring(0, 2000) + `\n\n... [${textContent.length - 2000} more characters]`
+      : textContent;
+    return (
+      <div className="mt-2 text-sm text-terminal-muted font-mono transition-opacity duration-150">
+        <pre className="overflow-x-auto max-h-64 rounded bg-terminal-dark/5 p-2 text-xs whitespace-pre-wrap break-words text-terminal-dark">
+          {displayText}
+        </pre>
+      </div>
+    );
+  }
+
   return null;
 });
 ToolResultDisplay.displayName = "ToolResultDisplay";
@@ -538,8 +554,15 @@ export const ToolFallback: ToolCallContentPartComponent = memo(({
         </details>
       )}
 
-      {/* Show result */}
-      {parsedResult && <ToolResultDisplay toolName={toolName} result={parsedResult} />}
+      {/* Show result in collapsible section */}
+      {parsedResult && (
+        <details className="text-xs text-terminal-muted">
+          <summary className="cursor-pointer hover:text-terminal-dark">
+            View output
+          </summary>
+          <ToolResultDisplay toolName={toolName} result={parsedResult} />
+        </details>
+      )}
     </div>
   );
 });

--- a/lib/ai/tool-registry/mcp-tool-adapter.ts
+++ b/lib/ai/tool-registry/mcp-tool-adapter.ts
@@ -475,6 +475,9 @@ export function mcpToolToMetadata(
         fullInstructions: mcpTool.description,
         loading: loadingConfig,  // Now dynamic based on preference
         requiresSession: false,
+        // MCP tool results are shown in UI but excluded from AI conversation history
+        // to save tokens (large outputs like browser snapshots are processed once)
+        ephemeralResults: true,
     };
 }
 

--- a/lib/ai/tool-registry/types.ts
+++ b/lib/ai/tool-registry/types.ts
@@ -74,6 +74,13 @@ export interface ToolMetadata {
 
   /** Environment variable that enables/disables this tool */
   enableEnvVar?: string;
+
+  /**
+   * If true, tool results are shown in UI but excluded from AI conversation history.
+   * Used to save tokens for large outputs like browser snapshots that the AI has
+   * already processed in the current turn.
+   */
+  ephemeralResults?: boolean;
 }
 
 /**

--- a/lib/messages/converter.ts
+++ b/lib/messages/converter.ts
@@ -169,10 +169,15 @@ function buildUIPartsFromDBContent(
           `[CONVERTER] Skipping tool call ${part.toolCallId} (${part.toolName}) with state "input-streaming" - likely a streaming interruption`
         );
         continue; // Skip incomplete streaming tool calls
+      } else {
+        // No args or argsText, but not in streaming state - assume empty args
+        // This handles tools that accept no parameters (e.g., MCP tools with optional params)
+        validInput = {};
       }
 
       const isValidInputObject =
         validInput !== undefined &&
+        validInput !== null &&
         typeof validInput === "object" &&
         !Array.isArray(validInput);
 


### PR DESCRIPTION
- Fix empty args handling for Claude via Antigravity (inject args: {} when missing)
- Fix streaming tool call finalization for tools with no parameters
- Add ephemeralResults flag to exclude MCP tool results from AI history
- Display MCP tool results in UI with collapsible "View output" section
- Truncate long results (2000 chars) in UI while keeping full result for AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now display in a collapsible format ("View output" summary) for improved readability.
  * MCP tool outputs now appear in the UI while being excluded from conversation history to optimize token usage.

* **Bug Fixes**
  * Fixed handling of parameter-less tool invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->