### PR TITLE
fix: harden streaming tool call JSON handling to prevent chat refresh

### DIFF
--- a/components/assistant-ui/execute-command-tool-ui.tsx
+++ b/components/assistant-ui/execute-command-tool-ui.tsx
@@ -16,11 +16,29 @@ export const ExecuteCommandToolUI: ToolCallContentPartComponent = ({
     args,
     result,
 }) => {
+    // Guard against missing or incomplete args (can happen when streaming
+    // is interrupted and argsText was malformed/truncated JSON)
+    if (!args || !args.command) {
+        if (result) {
+            // We have a result but no valid args - show result with fallback command
+            return (
+                <CommandOutput
+                    command="(unknown command)"
+                    stdout={result.stdout}
+                    stderr={result.stderr}
+                    exitCode={result.exitCode}
+                    executionTime={result.executionTime}
+                    success={result.status === "success"}
+                    error={result.status === "error" || result.status === "blocked" || result.status === "no_folders" ? result.error || result.message : undefined}
+                    defaultCollapsed={false}
+                />
+            );
+        }
+        return null;
+    }
+
     // If no result yet, show running state
     if (!result) {
-        // Guard against missing args
-        if (!args) return null;
-
         return (
             <CommandOutput
                 command={args.command}


### PR DESCRIPTION
fix: harden streaming tool call JSON handling to prevent chat refresh

- Add attemptJsonRepair() to close truncated JSON (missing braces/brackets/strings)
- finalizeStreamingToolCalls() now attempts repair before falling back to empty args
- syncStreamingMessage filters incomplete/malformed tool calls from DB persistence
- ChatErrorBoundary catches argsText SyntaxError and controller-closed errors as recoverable
- ExecuteCommandToolUI guards against missing/incomplete args from truncated argsText
- Suppress noisy "argsText updated after controller was closed" dev warnings

Root cause: during streaming, LLM tool calls arrive as incremental JSON chunks.
If the stream is interrupted or chunks arrive out of order, argsText contains
incomplete JSON like {"command":"python","args":["-c". This propagated to
assistant-ui's useToolInvocations which threw, triggering React error boundary
remount perceived as a page refresh. The fix adds defensive parsing at every
layer: server-side repair + DB filter + client-side error recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming reliability with enhanced error recovery for malformed data
  * Fixed handling of incomplete command arguments to prevent UI breaks
  * Added data validation to prevent invalid information from persisting in the chat

<!-- end of auto-generated comment: release notes by coderabbit.ai -->