### PR TITLE
fix(chat): inject fresh environment_details with current time per mes…

### DIFF
--- a/lib/ai/datetime-context.ts
+++ b/lib/ai/datetime-context.ts
@@ -95,6 +95,6 @@ Use this information for:
 - Relative time calculations ("this year", "last month", "recently")
 - Understanding temporal references in user messages
 
-Important: This is a snapshot generated at request start. For reminders/scheduling, backend validation uses runtime server time.`;
+Important: This time is regenerated fresh for every message. Always use the time shown here or in <environment_details>, never repeat a time you stated earlier in this conversation. For reminders/scheduling, backend validation uses runtime server time.`;
 }
 


### PR DESCRIPTION
…sage

Strip stale <environment_details> blocks from conversation history and inject a fresh one (server UTC time + user timezone) into the last user message on each request. This prevents the model from anchoring on a previously stated time when users ask "what time is it?" mid-conversation.

Follows the Roo Code pattern of per-message environment context injection with old block filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat system to automatically include current server time and timezone information with every message, ensuring the model has up-to-date environment context for more accurate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->