### PR TITLE
Clamp single tool-result stream budget to 25k and harden regression coverage

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -58,7 +58,10 @@ import {
   type FrontendMessage,
 } from "@/lib/messages/tool-enhancement";
 import { normalizeToolResultOutput } from "@/lib/ai/tool-result-utils";
-import { guardToolResultForStreaming } from "@/lib/ai/tool-result-stream-guard";
+import {
+  guardToolResultForStreaming,
+  MAX_STREAM_TOOL_RESULT_TOKENS,
+} from "@/lib/ai/tool-result-stream-guard";
 import {
   withRunContext,
   createAgentRun,
@@ -2407,9 +2410,13 @@ export async function POST(req: Request) {
     );
 
     const modelContextWindowLimit = getContextWindowLimit(currentModelId, currentProvider);
-    const streamToolResultBudgetTokens = Math.max(
+    const dynamicStreamBudgetTokens = Math.max(
       1,
       Math.floor(modelContextWindowLimit * 0.75 - contextCheck.status.currentTokens)
+    );
+    const streamToolResultBudgetTokens = Math.min(
+      MAX_STREAM_TOOL_RESULT_TOKENS,
+      dynamicStreamBudgetTokens
     );
     console.log(
       `[CHAT API] Tool-result stream budget: ${streamToolResultBudgetTokens.toLocaleString()} tokens ` +

--- a/lib/ai/tool-result-stream-guard.ts
+++ b/lib/ai/tool-result-stream-guard.ts
@@ -1,6 +1,7 @@
 import { estimateTokens } from "@/lib/ai/output-limiter";
 
 export const MIN_STREAM_TOOL_RESULT_TOKENS = 1;
+export const MAX_STREAM_TOOL_RESULT_TOKENS = 25_000;
 
 interface OversizedToolResult {
   status: "error";
@@ -45,10 +46,11 @@ function estimateTokensSafely(content: unknown): number {
 
 function normalizeTokenLimit(maxTokens?: number): number {
   if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens)) {
-    return Number.MAX_SAFE_INTEGER;
+    return MAX_STREAM_TOOL_RESULT_TOKENS;
   }
 
-  return Math.max(MIN_STREAM_TOOL_RESULT_TOKENS, Math.floor(maxTokens));
+  const normalized = Math.max(MIN_STREAM_TOOL_RESULT_TOKENS, Math.floor(maxTokens));
+  return Math.min(normalized, MAX_STREAM_TOOL_RESULT_TOKENS);
 }
 
 function extractRetrievalIds(result: unknown): {

--- a/tests/api/chat-history-fidelity.integration.test.ts
+++ b/tests/api/chat-history-fidelity.integration.test.ts
@@ -156,8 +156,14 @@ async function persistExecuteCommandToolRun(params: {
 
 describe.sequential("Chat Tool History Fidelity - Real Pipeline", () => {
   const integrationUserId = "integration-history-fidelity-user";
-  const forcedProvider: LLMProvider = "claudecode";
-  const forcedModel = "claude-haiku-4-5-20251001";
+  const runHistoryFidelityIntegration =
+    process.env.RUN_CHAT_HISTORY_FIDELITY_INTEGRATION === "true" &&
+    typeof process.env.OPENROUTER_API_KEY === "string" &&
+    process.env.OPENROUTER_API_KEY.trim().length > 0;
+  const integrationIt = runHistoryFidelityIntegration ? it : it.skip;
+  const forcedProvider: LLMProvider = "openrouter";
+  const forcedModel =
+    process.env.CHAT_HISTORY_INTEGRATION_MODEL ?? "anthropic/claude-sonnet-4.5";
   let originalSettings: AppSettings;
 
   beforeAll(() => {
@@ -176,7 +182,7 @@ describe.sequential("Chat Tool History Fidelity - Real Pipeline", () => {
     }
   });
 
-  it(
+  integrationIt(
     "executes 50 real tool runs, preserves canonical outputs losslessly, and recalls via /api/chat endpoint",
     async () => {
       const settings = loadSettings();
@@ -273,7 +279,7 @@ describe.sequential("Chat Tool History Fidelity - Real Pipeline", () => {
     1_200_000
   );
 
-  it(
+  integrationIt(
     "runs compaction on a large tool-result history and keeps call/result integrity in remaining history",
     async () => {
       const settings = loadSettings();


### PR DESCRIPTION
## What
- enforce a hard 25,000-token cap for a single streamed tool-result payload
- clamp dynamic stream tool-result budget in chat route to the same hard cap
- add regression tests for explicit oversized maxTokens and missing maxTokens behavior
- gate chat history fidelity integration test behind explicit env flag + OpenRouter key, and default model to Sonnet 4.5

## Why
Single tool outputs could still exceed safe streaming size when dynamic model-context budgets were large, causing stream instability. Oversized single-call tool outputs should be blocked and surfaced as tool errors so the agent can retry with narrower commands.

## Validation
- npm run test:run -- tests/lib/ai/tool-result-stream-guard.test.ts
- npm run test:run -- tests/lib/background-tasks/progress-content-limiter.test.ts tests/lib/ai/tool-result-utils.test.ts
- npm run test:integration -- tests/api/chat-history-fidelity.integration.test.ts (skips unless env enabled)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented proper token budget capping to prevent excessive streaming, ensuring more reliable AI response handling.
  * Improved token limit normalization with appropriate bounds to enhance system stability.

* **Tests**
  * Added test coverage for token limit enforcement and edge cases.
  * Enhanced integration test configuration with environment-driven settings for flexible testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->