### PR TITLE
fix(mcp): fallback when bundled node is unusable on packaged mac builds

### DIFF
--- a/lib/mcp/stdio-transport.ts
+++ b/lib/mcp/stdio-transport.ts
@@ -1,6 +1,6 @@
 import spawn from "cross-spawn";
 import type { ChildProcess, IOType } from "child_process";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import { PassThrough, type Stream } from "stream";
 import * as fs from "fs";
 import * as path from "path";
@@ -44,6 +44,13 @@ const MACOS_NODE_PATHS = [
     "/opt/homebrew/bin",
     "/opt/homebrew/sbin",
 ];
+
+type BundledNodeProbeCache = {
+    binaryPath: string;
+    usable: boolean;
+};
+
+let bundledNodeProbeCache: BundledNodeProbeCache | null = null;
 
 function normalizeExecutableName(command: string): string {
     const baseName = path.basename(command).toLowerCase();
@@ -116,6 +123,37 @@ type ResolvedSpawnCommand = {
     env?: Record<string, string>;
 };
 
+function isBundledNodeUsable(binaryPath: string): boolean {
+    if (bundledNodeProbeCache?.binaryPath === binaryPath) {
+        return bundledNodeProbeCache.usable;
+    }
+
+    try {
+        const probe = spawnSync(binaryPath, ["--version"], {
+            // Keep stdin as a pipe to avoid ignore-related EBADF issues in some Electron contexts.
+            stdio: ["pipe", "ignore", "ignore"],
+            windowsHide: true,
+            timeout: 2000,
+        });
+
+        const usable = !probe.error && probe.status === 0;
+        if (!usable) {
+            const reason = probe.error
+                ? probe.error.message
+                : `exitCode=${probe.status ?? "null"} signal=${probe.signal ?? "null"}`;
+            console.warn(`[MCP] Bundled node probe failed: ${binaryPath} (${reason})`);
+        }
+
+        bundledNodeProbeCache = { binaryPath, usable };
+        return usable;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[MCP] Bundled node probe threw for ${binaryPath}: ${message}`);
+        bundledNodeProbeCache = { binaryPath, usable: false };
+        return false;
+    }
+}
+
 /**
  * Get path to bundled Node.js binary (Windows and macOS, production builds)
  * Returns null if not found or not on a supported platform
@@ -125,8 +163,8 @@ function getBundledNodeExe(): string | null {
         return null;
     }
 
-    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
-        || process.env.ELECTRON_RESOURCES_PATH;
+    const resourcesPath = process.env.ELECTRON_RESOURCES_PATH
+        || (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
 
     if (!resourcesPath) {
         return null;
@@ -136,10 +174,22 @@ function getBundledNodeExe(): string | null {
     const bundledNodePath = path.join(resourcesPath, "standalone", "node_modules", ".bin", nodeBinaryName);
 
     try {
-        if (fs.existsSync(bundledNodePath)) {
-            console.log(`[MCP] Found bundled ${nodeBinaryName} at: ${bundledNodePath}`);
-            return bundledNodePath;
+        if (!fs.existsSync(bundledNodePath)) {
+            return null;
         }
+
+        if (process.platform !== "win32" && !isExecutable(bundledNodePath)) {
+            console.warn(`[MCP] Bundled ${nodeBinaryName} is not executable: ${bundledNodePath}`);
+            return null;
+        }
+
+        if (!isBundledNodeUsable(bundledNodePath)) {
+            console.warn(`[MCP] Bundled ${nodeBinaryName} is unusable, falling back to Electron runtime`);
+            return null;
+        }
+
+        console.log(`[MCP] Found bundled ${nodeBinaryName} at: ${bundledNodePath}`);
+        return bundledNodePath;
     } catch {
         // Ignore filesystem errors
     }
@@ -207,8 +257,8 @@ function prependPath(existingPath: string | undefined, extraDir: string): string
 function getBundledNpmCliPath(cliName: "npx-cli.js" | "npm-cli.js"): string | null {
     // In packaged Electron apps, process.resourcesPath is only available in the main process.
     // For the Next.js server (child process), we use ELECTRON_RESOURCES_PATH env var.
-    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath 
-        || process.env.ELECTRON_RESOURCES_PATH;
+    const resourcesPath = process.env.ELECTRON_RESOURCES_PATH
+        || (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
     
     const candidates = [
         // Primary: bundled in resources/standalone/node_modules/npm/bin/


### PR DESCRIPTION

- Added a **bundled node health probe** in `lib/mcp/stdio-transport.ts:126`:
  - New `isBundledNodeUsable()` runs `spawnSync(<bundled-node>, ["--version"])` with a short timeout.
  - Caches probe results so startup doesn’t repeatedly re-probe.
- Hardened bundled runtime resolution in `lib/mcp/stdio-transport.ts:161`:
  - `getBundledNodeExe()` now checks:
    - file exists,
    - executable bit on Unix,
    - binary is actually runnable.
  - If any check fails, it **falls back to Electron runtime** (`process.execPath` + `ELECTRON_RUN_AS_NODE`) instead of hard-failing MCP startup.
- Ensured utility-process path precedence in `lib/mcp/stdio-transport.ts:166` and `lib/mcp/stdio-transport.ts:260`:
  - Prefer `ELECTRON_RESOURCES_PATH` first (more accurate for packaged Next/Electron utility process context).
- Added regression coverage in `tests/mcp-stdio-transport.integration.test.ts:201`:
  - New test `falls back to Electron runtime when bundled node binary is unusable`.
  - Builds synthetic packaged resources with:
    - valid bundled `npx-cli.js`,
    - intentionally broken bundled `node`,
    - utility-process-like env (`ELECTRON_RESOURCES_PATH` only).
  - Verifies MCP startup succeeds and does **not** use broken bundled node path.

Why this addresses the user report
- User logs show bundled path chosen and then `Connection closed` right after spawn.  
- This fix directly handles the most plausible packaged-only failure mode: bundled node exists but is unusable on that machine/build context.  
- Result: MCP launch now gracefully degrades to Electron runtime instead of dying.

Validation I ran
- `npm run typecheck` ✅
- `npm run test:run -- tests/mcp-stdio-transport.integration.test.ts` ✅
- `npm run test:run -- tests/lib/command-execution/bundled-binaries.test.ts` ✅
- `npm run test:run -- tests/mcp-stdio-transport.integration.test.ts tests/lib/command-execution/bundled-binaries.test.ts` ✅

Git status
- Branch: `fix/mcp-bundled-npx-macos`
- Commit: `b7669da`
- Pushed: `origin/fix/mcp-bundled-npx-macos`

PR status
- I attempted to create PR with `gh`, but local auth is missing:
  - `gh auth login` required, and no `GH_TOKEN`/`GITHUB_TOKEN` present.
- PR URL to open manually right now:
  - `https://github.com/tercumantanumut/seline/pull/new/fix/mcp-bundled-npx-macos`


Git title/description
- Title: `fix(mcp): fallback when bundled node is unusable on packaged mac builds`
- Description: “Guard MCP packaged runtime selection with executable + runnability checks for bundled node, and fallback to Electron runtime when probe fails; add integration regression test for unusable bundled node in utility-process-style environment.”
