### PR TITLE
fix(mcp): harden packaged node runtime and mac libnode bundling

### DIFF
--- a/scripts/verify-package.js
+++ b/scripts/verify-package.js
@@ -100,6 +100,9 @@ const requiredPaths = [
     : 'standalone/node_modules/.bin/node',
   'standalone/node_modules/npm/bin/npm-cli.js',
   'standalone/node_modules/npm/bin/npx-cli.js',
+  ...(platform === 'darwin' || platform === 'mac'
+    ? ['standalone/node_modules/lib']
+    : []),
 ];
 
 // RTK bundle is optional at runtime (experimental), but warn if absent in package.
@@ -118,6 +121,17 @@ for (const required of requiredPaths) {
   if (!fs.existsSync(fullPath)) {
     console.error(`   ❌ FAIL: Missing required file/folder: ${required}`);
     hasErrors = true;
+  }
+}
+
+if (platform === 'darwin' || platform === 'mac') {
+  const nodeLibDir = path.join(appResourcesPath, 'standalone', 'node_modules', 'lib');
+  if (fs.existsSync(nodeLibDir)) {
+    const libnodeFiles = fs.readdirSync(nodeLibDir).filter((name) => /^libnode\..+\.dylib$/i.test(name));
+    if (libnodeFiles.length === 0) {
+      console.error('   ❌ FAIL: Missing libnode*.dylib in standalone/node_modules/lib');
+      hasErrors = true;
+    }
   }
 }
 


### PR DESCRIPTION
## Why
Packaged macOS builds can report:

- `[MCP] Bundled node is unusable, falling back to Electron runtime`
- `MCP error -32000: Connection closed`

This can happen when bundled node exists but is not runnable (or is missing its sidecar `libnode*.dylib` files), causing broad stdio MCP failures.

## What changed
- `lib/mcp/stdio-transport.ts`
  - Probe bundled node runnability with `spawnSync(node, ["--version"])` and cache result.
  - Prefer `ELECTRON_RESOURCES_PATH` for packaged utility-process/server contexts.
  - For `npm`/`npx` and `node` commands, runtime order is now:
    1) bundled node,
    2) verified system node from PATH/known macOS locations,
    3) Electron-as-Node last.
  - Added `/usr/bin` to known macOS fallback paths.

- `scripts/electron-prepare.js`
  - Add `copyBundledNodeMacLibraries()`.
  - On macOS packaging, copy `libnode*.dylib` from Node's sibling `lib` directory into:
    `standalone/node_modules/lib`.
  - Resolve real path of source node binary before locating `../lib`.

- `scripts/verify-package.js`
  - macOS packaging verification now requires `standalone/node_modules/lib`.
  - Fails verification if no `libnode*.dylib` is found there.

- `tests/mcp-stdio-transport.integration.test.ts`
  - Updated bundled npm CLI test to allow either bundled node or verified system node runtime.
  - Added regression test for unusable bundled node: verifies fallback to system node and no `ELECTRON_RUN_AS_NODE`.

## Validation
- `npm run typecheck` ✅
- `npm run test:run -- tests/mcp-stdio-transport.integration.test.ts` ✅
- `npm run test:run -- tests/lib/command-execution/bundled-binaries.test.ts` ✅

## Notes
- This keeps existing healthy bundled-node behavior intact.
- It hardens packaged macOS builds against both runtime incompatibility and missing libnode sidecars.
