### PR TITLE
fix(hooks): escape spaces in plugin root path for shell execution

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -125,7 +125,7 @@ extraResources:
 asar: true
 compression: "normal"
 
-# Run notarization hook after macOS signing completes.
+# Signing & notarization disabled for now.
 # afterSign: "scripts/notarize.js"
 
 # Disable npm rebuild - we handle this in electron:rebuild-standalone
@@ -135,10 +135,6 @@ npmRebuild: false
 mac:
   category: "public.app-category.entertainment"
   identity: null
-  hardenedRuntime: false
-  gatekeeperAssess: false
-  entitlements: "build-resources/entitlements.mac.plist"
-  entitlementsInherit: "build-resources/entitlements.mac.inherit.plist"
   # icon: "build-resources/icon.icns"
   # Build only for current architecture by default (use CLI flags to override)
   target:
@@ -147,6 +143,7 @@ mac:
   extendInfo:
     NSCameraUsageDescription: "This app requires access to your camera for image capture."
     NSMicrophoneUsageDescription: "This app requires access to your microphone for audio capture."
+    NSUserNotificationAlertStyle: "alert"
 
 # Windows specific configuration
 win:

--- a/lib/plugins/hooks-engine.ts
+++ b/lib/plugins/hooks-engine.ts
@@ -337,8 +337,12 @@ async function executeCommandHook(
 
   // Substitute ${CLAUDE_PLUGIN_ROOT} only when we have a concrete root.
   // If root is unknown, keep the placeholder intact so shell/env expansion can still work.
+  // Escape spaces in the path (e.g. macOS "Application Support") so /bin/sh -c doesn't break.
+  const escapedRoot = pluginRoot ? pluginRoot.replace(/ /g, "\\ ") : "";
   const resolvedCommand = pluginRoot
-    ? command.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot)
+    ? command
+        .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, escapedRoot)
+        .replace(/\$CLAUDE_PLUGIN_ROOT/g, escapedRoot)
     : command;
 
   const timeoutMs = (handler.timeout || 600) * 1000;


### PR DESCRIPTION
macOS production builds store plugin files under ~/Library/Application Support/ which contains a space. The hook engine passes commands through /bin/sh -c without escaping, causing the path to break. Also cleans up unused signing config and adds NSUserNotificationAlertStyle for macOS notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration, temporarily disabling signing and notarization.
  
* **Bug Fixes**
  * Improved plugin path handling to properly support directory names containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->