### PR TITLE
fix: prevent false duplicate-agent failure toast on slow duplication

### DIFF
--- a/components/character-picker-agent-card.tsx
+++ b/components/character-picker-agent-card.tsx
@@ -25,6 +25,7 @@ export function AgentCardInWorkflow({
   onEditMcp,
   onEditPlugins,
   onDuplicate,
+  isDuplicating = false,
   addToWorkflowLabel,
   onAddToWorkflow,
   canAddToWorkflow,
@@ -46,6 +47,7 @@ export function AgentCardInWorkflow({
   onEditMcp: (c: CharacterSummary) => void;
   onEditPlugins: (c: CharacterSummary) => void;
   onDuplicate: (characterId: string) => void;
+  isDuplicating?: boolean;
   addToWorkflowLabel?: string;
   onAddToWorkflow?: (c: CharacterSummary) => void;
   canAddToWorkflow?: boolean;
@@ -80,6 +82,7 @@ export function AgentCardInWorkflow({
           onEditPlugins={onEditPlugins}
           onNavigateDashboard={() => router.push("/dashboard")}
           onDuplicate={onDuplicate}
+          isDuplicating={isDuplicating}
           addToWorkflowLabel={addToWorkflowLabel}
           onAddToWorkflow={onAddToWorkflow}
           showAddToWorkflow={Boolean(onAddToWorkflow)}

--- a/components/character-picker-agent-overflow-menu.tsx
+++ b/components/character-picker-agent-overflow-menu.tsx
@@ -33,6 +33,7 @@ export type AgentOverflowMenuProps = {
   onEditPlugins: (c: CharacterSummary) => void;
   onNavigateDashboard: () => void;
   onDuplicate: (characterId: string) => void;
+  isDuplicating?: boolean;
   addToWorkflowLabel?: string;
   onAddToWorkflow?: (c: CharacterSummary) => void;
   showAddToWorkflow?: boolean;
@@ -51,6 +52,7 @@ export function AgentOverflowMenu({
   onEditPlugins,
   onNavigateDashboard,
   onDuplicate,
+  isDuplicating = false,
   addToWorkflowLabel,
   onAddToWorkflow,
   showAddToWorkflow = true,
@@ -103,7 +105,7 @@ export function AgentOverflowMenu({
           {t("menu.dashboard")}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => onDuplicate(character.id)}>
+        <DropdownMenuItem disabled={isDuplicating} onSelect={() => onDuplicate(character.id)}>
           <Copy className="w-3.5 h-3.5 mr-2" />
           {t("menu.duplicate")}
         </DropdownMenuItem>

--- a/components/character-picker-character-actions-hook.ts
+++ b/components/character-picker-character-actions-hook.ts
@@ -29,6 +29,9 @@ export function useCharacterActions(
   const [characterToDelete, setCharacterToDelete] = useState<CharacterSummary | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // Duplicate state
+  const [isDuplicating, setIsDuplicating] = useState(false);
+
   // Folder manager state
   const [folderManagerOpen, setFolderManagerOpen] = useState(false);
   const [folderManagerCharacter, setFolderManagerCharacter] = useState<CharacterSummary | null>(null);
@@ -255,6 +258,9 @@ export function useCharacterActions(
 
   // Duplicate action
   const handleDuplicate = async (characterId: string) => {
+    if (isDuplicating) return;
+
+    setIsDuplicating(true);
     try {
       const { data, error } = await resilientPost<{ character: { id: string } }>(
         `/api/characters/${characterId}/duplicate`,
@@ -268,6 +274,8 @@ export function useCharacterActions(
     } catch (error) {
       console.error("Failed to duplicate agent:", error);
       toast.error(t("workflows.duplicateFailed"));
+    } finally {
+      setIsDuplicating(false);
     }
   };
 
@@ -328,6 +336,7 @@ export function useCharacterActions(
     toggleAgentPlugin,
 
     // Duplicate
+    isDuplicating,
     handleDuplicate,
   };
 }

--- a/components/character-picker-workflow-section.tsx
+++ b/components/character-picker-workflow-section.tsx
@@ -49,6 +49,7 @@ export function WorkflowCard({
   onEditMcp,
   onEditPlugins,
   onDuplicate,
+  isDuplicating,
   onDeleteCharacter,
   onOpenFolderManager,
 }: {
@@ -75,6 +76,7 @@ export function WorkflowCard({
   onEditMcp: (c: CharacterSummary) => void;
   onEditPlugins: (c: CharacterSummary) => void;
   onDuplicate: (id: string) => void;
+  isDuplicating: boolean;
   onDeleteCharacter: (c: CharacterSummary) => void;
   onOpenFolderManager: (c: CharacterSummary) => void;
 }) {
@@ -298,6 +300,7 @@ export function WorkflowCard({
                     onEditMcp={onEditMcp}
                     onEditPlugins={onEditPlugins}
                     onDuplicate={onDuplicate}
+                    isDuplicating={isDuplicating}
                     onDelete={onDeleteCharacter}
                     router={router}
                   />
@@ -335,6 +338,7 @@ export function WorkflowCard({
                         onEditMcp={onEditMcp}
                         onEditPlugins={onEditPlugins}
                         onDuplicate={onDuplicate}
+                        isDuplicating={isDuplicating}
                         onDelete={onDeleteCharacter}
                         onRemoveFromWorkflow={() => {
                           onSetPendingMemberRemoval({ workflowId: wf.id, agentId: agent.id });
@@ -385,6 +389,7 @@ export function WorkflowSection({
   onEditMcp,
   onEditPlugins,
   onDuplicate,
+  isDuplicating,
   onDeleteCharacter,
   onOpenFolderManager,
 }: {
@@ -414,6 +419,7 @@ export function WorkflowSection({
   onEditMcp: (c: CharacterSummary) => void;
   onEditPlugins: (c: CharacterSummary) => void;
   onDuplicate: (id: string) => void;
+  isDuplicating: boolean;
   onDeleteCharacter: (c: CharacterSummary) => void;
   onOpenFolderManager: (c: CharacterSummary) => void;
 }) {
@@ -477,6 +483,7 @@ export function WorkflowSection({
               onEditMcp={onEditMcp}
               onEditPlugins={onEditPlugins}
               onDuplicate={onDuplicate}
+              isDuplicating={isDuplicating}
               onDeleteCharacter={onDeleteCharacter}
               onOpenFolderManager={onOpenFolderManager}
             />

--- a/components/character-picker.tsx
+++ b/components/character-picker.tsx
@@ -378,6 +378,7 @@ export function CharacterPicker() {
             onEditMcp={charActions.openMcpToolEditor}
             onEditPlugins={charActions.openPluginEditor}
             onDuplicate={charActions.handleDuplicate}
+            isDuplicating={charActions.isDuplicating}
             onDeleteCharacter={charActions.openDeleteDialog}
             onOpenFolderManager={charActions.openFolderManager}
           />
@@ -439,6 +440,7 @@ export function CharacterPicker() {
               onEditMcp={charActions.openMcpToolEditor}
               onEditPlugins={charActions.openPluginEditor}
               onDuplicate={charActions.handleDuplicate}
+              isDuplicating={charActions.isDuplicating}
               addToWorkflowLabel={t("workflows.addToWorkflow")}
               onAddToWorkflow={openAddToWorkflowDialog}
               canAddToWorkflow={(availableWorkflowsByAgentId.get(character.id) || []).length > 0}


### PR DESCRIPTION
## Summary
- increase duplicate-agent request timeout from 10s to 60s in the character picker action
- avoid false `Failed to duplicate agent` toast when duplication succeeds but takes longer due to copying folders/plugins/images

## Validation
- `npm run typecheck` ✅
- `LOCAL_DATA_PATH=$(mktemp -d) npm run test -- --reporter=dot --silent` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now reflects duplication activity (shows/disables duplicate action while duplicating).
* **Bug Fixes**
  * Duplicate operations are guarded against concurrent runs and now time out after 60 seconds with no automatic retries, preventing stuck states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->