### PR TITLE
fix(antigravity): port Gemini 3.1 Pro fixes from upstream v1.6.0

### DIFF
--- a/lib/auth/antigravity-auth.ts
+++ b/lib/auth/antigravity-auth.ts
@@ -51,7 +51,7 @@ export const ANTIGRAVITY_OAUTH = {
 } as const;
 
 // Antigravity API configuration
-const ANTIGRAVITY_VERSION = "1.15.8";
+const ANTIGRAVITY_VERSION = "1.18.3";
 
 export const ANTIGRAVITY_CONFIG = {
   // API endpoints in fallback order (daily → autopush → prod)


### PR DESCRIPTION
Bump ANTIGRAVITY_VERSION to 1.18.3 and add request payload sanitization for thoughtSignature handling on parallel functionCall parts, preventing 400 INVALID_ARGUMENT errors with gemini-3.1-pro models.