### PR TITLE
Improve session search to include message content and all channels

### DIFF
--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest) {
     const cursor = searchParams.get("cursor") ?? undefined;
     const limit = Number.parseInt(searchParams.get("limit") || "20", 10);
     const search = searchParams.get("search")?.trim() || undefined;
-    const channelType = (searchParams.get("channelType") as "whatsapp" | "telegram" | "slack" | null) ?? undefined;
+    const channelType = (searchParams.get("channelType") as "app" | "whatsapp" | "telegram" | "slack" | "discord" | null) ?? undefined;
     const dateRange = (searchParams.get("dateRange") as "today" | "week" | "month" | "all" | null) ?? undefined;
     const statusParam = (searchParams.get("status") as "active" | "archived" | null) ?? undefined;
     const wantsPagination =

--- a/docs/agent-prompts/session-search.md
+++ b/docs/agent-prompts/session-search.md
@@ -9,7 +9,7 @@ You are a session search specialist on the Seline platform. You find and rank pa
 
 ## Tools
 
-- **`searchSessions`** — Query past sessions by title, agent, channel, or date range. Returns metadata and compaction summaries (not message content).
+- **`searchSessions`** — Query past sessions by title, message content, agent, channel, or date range. Returns metadata and compaction summaries (not full message dumps).
 - **`readFile`** — Read session transcripts when deeper inspection is needed.
 
 ## Seline Session Metadata

--- a/lib/ai/tool-registry/tool-definitions.ts
+++ b/lib/ai/tool-registry/tool-definitions.ts
@@ -154,13 +154,13 @@ export function registerAllTools(): void {
         "find", "search", "chat", "thread", "recall", "context",
       ],
       shortDescription:
-        "Search past conversation sessions by title, channel, agent, or date range",
+        "Search past sessions by title, message content, channel, agent, or date range",
       fullInstructions: `## Search Sessions
 
-Search and filter past conversations. Returns metadata and summaries — not message content.
+Search and filter past conversations. Returns session metadata and summaries (no full message dump).
 
-**Filters:** query (title search), characterName, channelType (whatsapp/telegram/slack), dateRange (today/week/month/all).
-**Use when:** user asks "what did we discuss about X?", "find my Telegram chats", "recent sessions with agent Y".
+**Filters:** query (title + message-content search by default), characterName, channelType (app/whatsapp/telegram/slack/discord), dateRange (today/week/month/all), includeMessageContent (default true).
+**Use when:** user asks "what did we discuss about X?", "find my Telegram chats", "recent sessions with agent Y", or "search what we did yesterday".
 **Limit:** Max 50 results per call. Default 20.`,
       loading: { deferLoading: true },
       requiresSession: true,

--- a/lib/ai/tools/search-sessions-tool.ts
+++ b/lib/ai/tools/search-sessions-tool.ts
@@ -10,8 +10,9 @@ interface SearchSessionsToolOptions {
 interface SearchSessionsArgs {
   query?: string;
   characterName?: string;
-  channelType?: "whatsapp" | "telegram" | "slack";
+  channelType?: "app" | "whatsapp" | "telegram" | "slack" | "discord";
   dateRange?: "today" | "week" | "month" | "all";
+  includeMessageContent?: boolean;
   limit?: number;
 }
 
@@ -23,7 +24,7 @@ const searchSessionsSchema = jsonSchema<SearchSessionsArgs>({
     query: {
       type: "string",
       description:
-        "Search term to match against session titles (e.g., 'authentication', 'deploy')",
+        "Search term to match against session titles and recent message content (e.g., 'authentication', 'deploy')",
     },
     characterName: {
       type: "string",
@@ -32,13 +33,18 @@ const searchSessionsSchema = jsonSchema<SearchSessionsArgs>({
     },
     channelType: {
       type: "string",
-      enum: ["whatsapp", "telegram", "slack"],
+      enum: ["app", "whatsapp", "telegram", "slack", "discord"],
       description: "Filter by the channel where the conversation happened",
     },
     dateRange: {
       type: "string",
       enum: ["today", "week", "month", "all"],
       description: "Filter by recency. Defaults to 'all'.",
+    },
+    includeMessageContent: {
+      type: "boolean",
+      description:
+        "Also match the query against non-compacted user/assistant message content. Defaults to true.",
     },
     limit: {
       type: "number",
@@ -80,7 +86,10 @@ async function executeSearchSessions(
 
   const result = await listSessionsPaginated({
     userId: options.userId,
+    characterName: args.characterName,
     search: args.query,
+    // Default to message-content matching so "what we did yesterday" finds non-title sessions.
+    searchInMessages: args.includeMessageContent ?? true,
     channelType: args.channelType,
     dateRange: args.dateRange ?? "all",
     limit: safeLimit,
@@ -107,7 +116,7 @@ export function createSearchSessionsTool(options: SearchSessionsToolOptions) {
   );
 
   return tool({
-    description: `Search past conversation sessions by title, channel, agent, or date range. Returns session metadata and summaries — not message content.`,
+    description: `Search past conversation sessions by title, message content, channel, agent, or date range. Returns session metadata and summaries — not message dumps.`,
     inputSchema: searchSessionsSchema,
     execute: executeWithLogging,
   });

--- a/lib/characters/templates/system-agents.ts
+++ b/lib/characters/templates/system-agents.ts
@@ -81,7 +81,7 @@ You can only explore and plan. You CANNOT write, edit, or modify any files.
 
 ## Tools
 
-- **\`searchSessions\`** — Query past sessions by title, agent, channel, or date range. Returns metadata and compaction summaries (not message content).
+- **\`searchSessions\`** — Query past sessions by title, message content, agent, channel, or date range. Returns metadata and compaction summaries (not full message dumps).
 - **\`readFile\`** — Read session transcripts when deeper inspection is needed.
 
 ## Seline Session Metadata

--- a/lib/db/queries-sessions.ts
+++ b/lib/db/queries-sessions.ts
@@ -1,7 +1,7 @@
 import { db } from "./sqlite-client";
 import { sessions, agentRuns, messages } from "./sqlite-schema";
 import type { NewSession, Session } from "./sqlite-schema";
-import { eq, desc, asc, and, lt, sql, like, inArray } from "drizzle-orm";
+import { eq, desc, asc, and, lt, sql, inArray, type SQL } from "drizzle-orm";
 
 export type SessionMetadataShape = {
   characterId?: string;
@@ -11,10 +11,12 @@ export type SessionMetadataShape = {
 export interface ListSessionsPaginatedParams {
   userId: string;
   characterId?: string;
+  characterName?: string;
   cursor?: string;
   limit?: number;
   search?: string;
-  channelType?: "whatsapp" | "telegram" | "slack";
+  searchInMessages?: boolean;
+  channelType?: "app" | "whatsapp" | "telegram" | "slack" | "discord";
   dateRange?: "today" | "week" | "month" | "all";
   status?: "active" | "archived";
 }
@@ -187,16 +189,44 @@ export async function listSessionsPaginated(
 ): Promise<ListSessionsPaginatedResult> {
   const pageSize = Math.min(Math.max(params.limit ?? 20, 1), 100);
   const statusFilter = params.status ?? "active";
-  const baseConditions = [eq(sessions.userId, params.userId), eq(sessions.status, statusFilter)];
+  const baseConditions: SQL[] = [eq(sessions.userId, params.userId), eq(sessions.status, statusFilter)];
 
   if (params.characterId) {
     baseConditions.push(eq(sessions.characterId, params.characterId));
   }
-  if (params.search) {
-    baseConditions.push(like(sessions.title, `%${params.search}%`));
+  if (params.characterName) {
+    const escapedCharacterName = params.characterName.replace(/[\\%_]/g, "\\$&");
+    baseConditions.push(sql`json_extract(${sessions.metadata}, '$.characterName') LIKE ${`%${escapedCharacterName}%`} ESCAPE '\\'`);
   }
-  if (params.channelType) {
-    baseConditions.push(eq(sessions.channelType, params.channelType));
+  if (params.search) {
+    const escapedSearch = params.search.replace(/[\\%_]/g, "\\$&");
+    const likePattern = `%${escapedSearch}%`;
+    const titleSearch = sql`${sessions.title} LIKE ${likePattern} ESCAPE '\\'`;
+    const messageSearch = sql`EXISTS (
+      SELECT 1
+      FROM ${messages}
+      WHERE ${messages.sessionId} = ${sessions.id}
+        AND (${messages.isCompacted} IS NULL OR ${messages.isCompacted} = 0)
+        AND ${messages.role} IN ('user', 'assistant')
+        AND CAST(${messages.content} AS TEXT) LIKE ${likePattern} ESCAPE '\\'
+    )`;
+
+    baseConditions.push(
+      params.searchInMessages
+        ? sql`(${titleSearch}) OR (${messageSearch})`
+        : titleSearch
+    );
+  }
+  if (params.channelType === "app") {
+    baseConditions.push(
+      sql`(${sessions.channelType} IS NULL OR json_extract(${sessions.metadata}, '$.channelType') = 'app')`
+    );
+  } else if (params.channelType === "discord") {
+    baseConditions.push(
+      sql`json_extract(${sessions.metadata}, '$.channelType') = 'discord'`
+    );
+  } else if (params.channelType) {
+    baseConditions.push(eq(sessions.channelType, params.channelType as "whatsapp" | "telegram" | "slack"));
   }
 
   if (params.dateRange && params.dateRange !== "all") {

--- a/tests/lib/ai/tools/search-sessions-tool.test.ts
+++ b/tests/lib/ai/tools/search-sessions-tool.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  listSessionsPaginated: vi.fn(),
+}));
+
+const loggingMocks = vi.hoisted(() => ({
+  withToolLogging: vi.fn(
+    (_toolName: string, _sessionId: string | undefined, executeFn: (args: any, options?: any) => Promise<any>) =>
+      (args: any, options?: any) => executeFn(args, options)
+  ),
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  listSessionsPaginated: dbMocks.listSessionsPaginated,
+}));
+
+vi.mock("@/lib/ai/tool-registry/logging", () => ({
+  withToolLogging: loggingMocks.withToolLogging,
+}));
+
+import { createSearchSessionsTool } from "@/lib/ai/tools/search-sessions-tool";
+
+function createTool() {
+  return createSearchSessionsTool({
+    sessionId: "sess-1",
+    userId: "user-1",
+  });
+}
+
+describe("searchSessions tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to message-content search and forwards character/channel filters", async () => {
+    dbMocks.listSessionsPaginated.mockResolvedValue({
+      totalCount: 1,
+      sessions: [
+        {
+          id: "s1",
+          title: "Debugging sessions",
+          summary: "x".repeat(350),
+          metadata: { characterName: "Session Search", pinned: true },
+          channelType: "slack",
+          messageCount: 42,
+          lastMessageAt: "2026-02-25T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const tool = createTool();
+    const result = await tool.execute(
+      {
+        query: "what we did yesterday",
+        characterName: "Session Search",
+        channelType: "slack",
+      },
+      { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+    ) as any;
+
+    expect(dbMocks.listSessionsPaginated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        search: "what we did yesterday",
+        characterName: "Session Search",
+        channelType: "slack",
+        searchInMessages: true,
+      })
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.totalCount).toBe(1);
+    expect(result.returned).toBe(1);
+    expect(result.sessions[0]).toMatchObject({
+      id: "s1",
+      title: "Debugging sessions",
+      agent: "Session Search",
+      channel: "slack",
+      pinned: true,
+      messageCount: 42,
+    });
+    expect(result.sessions[0].summary.endsWith("…")).toBe(true);
+  });
+
+  it("respects includeMessageContent=false and clamps limit", async () => {
+    dbMocks.listSessionsPaginated.mockResolvedValue({
+      totalCount: 0,
+      sessions: [],
+    });
+
+    const tool = createTool();
+    await tool.execute(
+      {
+        query: "exact title only",
+        includeMessageContent: false,
+        limit: 999,
+        channelType: "discord",
+      },
+      { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+    );
+
+    expect(dbMocks.listSessionsPaginated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: "exact title only",
+        searchInMessages: false,
+        channelType: "discord",
+        limit: 50,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- updated `searchSessions` to search both session titles and non-compacted user/assistant message content by default
- added optional `includeMessageContent` input (defaults to `true`) to allow title-only behavior when needed
- enabled `channelType` filters for `app` and `discord` in the tool and API parsing layer
- added `characterName` filtering support in session pagination query path
- refreshed prompt/tool docs for Session Search to reflect actual behavior
- added focused tests for the new `searchSessions` behavior and defaults

## Root cause
`searchSessions` was effectively title-only because it passed `query` into `listSessionsPaginated(search)` which only matched `sessions.title`. Also, channel filtering accepted only whatsapp/telegram/slack in several paths.

## Validation
- `npm run typecheck`
- `npm run test:run -- tests/lib/ai/tools/search-sessions-tool.test.ts`

## Notes
- Results still return metadata + summary only (no full message dump), but relevance now accounts for message text when requested/default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for App and Discord channels in session searches
  * Session search now includes message content by default, in addition to titles
  * Added optional toggle to control message content inclusion in searches

* **Documentation**
  * Updated session search documentation to reflect expanded search capabilities

* **Tests**
  * Added test coverage for the search sessions tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->