### PR TITLE
fix: isolate Agent SDK tool exposure and wire deferred loading

### DIFF
--- a/app/api/chat/tools-builder.ts
+++ b/app/api/chat/tools-builder.ts
@@ -87,6 +87,12 @@ export interface ToolsBuildResult {
   hasFailureHooks: boolean;
   discoveredTools: Set<string>;
   initialActiveTools: Set<string>;
+  /** MCP server names enabled for the current agent (forwarded to SelineMcpContext) */
+  enabledMcpServers?: string[];
+  /** Specific MCP tool IDs enabled for the current agent (forwarded to SelineMcpContext) */
+  enabledMcpTools?: string[];
+  /** MCP tool IDs that are alwaysLoad (forwarded to SelineMcpContext for deferred gating) */
+  alwaysLoadMcpToolIds: string[];
 }
 
 // ─── Main builder ────────────────────────────────────────────────────────────
@@ -277,6 +283,8 @@ export async function buildToolsForRequest(
     allTools: Record<string, Tool>;
     alwaysLoadToolIds: string[];
     deferredToolIds: string[];
+    enabledMcpServers?: string[];
+    enabledMcpTools?: string[];
   } = { allTools: {}, alwaysLoadToolIds: [], deferredToolIds: [] };
 
   try {
@@ -667,5 +675,8 @@ export async function buildToolsForRequest(
     hasFailureHooks,
     discoveredTools,
     initialActiveTools,
+    enabledMcpServers: mcpToolResult.enabledMcpServers,
+    enabledMcpTools: mcpToolResult.enabledMcpTools,
+    alwaysLoadMcpToolIds: mcpToolResult.alwaysLoadToolIds,
   };
 }

--- a/lib/ai/providers/mcp-context-store.ts
+++ b/lib/ai/providers/mcp-context-store.ts
@@ -35,6 +35,49 @@ export interface SelineMcpContext {
     allowedPluginNames: Set<string>;
     pluginRoots: Map<string, string>;
   };
+
+  // ── SDK-specific tool loading and isolation fields ─────────────────────────
+
+  /**
+   * Tool loading mode for the Agent SDK — mirrors the app-level setting.
+   * When "deferred", non-alwaysLoad tools require searchTools discovery first.
+   * When "always", all enabled tools are active immediately.
+   */
+  toolLoadingMode?: "deferred" | "always";
+
+  /**
+   * Tool names previously discovered via searchTools in earlier turns.
+   * Seeds the SDK session's activated-tools set so discoveries from prior
+   * requests persist (Agent SDK runs one full session per request).
+   */
+  previouslyDiscoveredTools?: string[];
+
+  /**
+   * MCP server names enabled for this agent (from character metadata).
+   * Scopes MCPClientManager tool exposure to only this agent's servers.
+   * When undefined + no enabledMcpTools, all connected servers are accessible.
+   */
+  enabledMcpServers?: string[];
+
+  /**
+   * Specific MCP tool IDs (format: "serverName:toolName") enabled for this agent.
+   * Takes precedence over enabledMcpServers when set.
+   */
+  enabledMcpTools?: string[];
+
+  /**
+   * MCP tool IDs (in getMCPToolId format, e.g. "mcp_server_tool") that are
+   * alwaysLoad (active immediately without searchTools). Populated from
+   * mcpToolPreferences in character metadata.
+   */
+  alwaysLoadMcpToolIds?: string[];
+
+  /**
+   * Callback fired when an SDK MCP tool produces rich output (image URL, video URL, etc.).
+   * Route.ts wires this into the Seline streaming state so image/video chips
+   * appear in the UI even when using the Agent SDK provider.
+   */
+  onRichOutput?: (toolCallId: string, toolName: string, output: unknown) => void;
 }
 
 export const mcpContextStore = new AsyncLocalStorage<SelineMcpContext>();

--- a/lib/mcp/chat-integration.ts
+++ b/lib/mcp/chat-integration.ts
@@ -22,6 +22,17 @@ export interface MCPToolLoadResult {
     alwaysLoadToolIds: string[];
     /** Tool IDs that are deferred (discoverable via searchTools) */
     deferredToolIds: string[];
+    /**
+     * MCP server names enabled for this agent (from character metadata).
+     * Forwarded to SelineMcpContext so the SDK MCP server can scope
+     * MCPClientManager.getAllTools() to only this agent's servers.
+     */
+    enabledMcpServers?: string[];
+    /**
+     * Specific MCP tool IDs (format: "serverName:toolName") enabled for this agent.
+     * Forwarded to SelineMcpContext for per-tool isolation in the SDK bridge.
+     */
+    enabledMcpTools?: string[];
 }
 
 /**
@@ -196,5 +207,11 @@ export async function loadMCPToolsForCharacter(
         console.log(`[MCP] Loaded ${Object.keys(allTools).length} MCP tools (${alwaysLoadToolIds.length} always-load, ${deferredToolIds.length} deferred)`);
     }
 
-    return { allTools, alwaysLoadToolIds, deferredToolIds };
+    return {
+        allTools,
+        alwaysLoadToolIds,
+        deferredToolIds,
+        enabledMcpServers: enabledServers,
+        enabledMcpTools: enabledTools,
+    };
 }


### PR DESCRIPTION
## Summary

- **MCP tool isolation**: replaced `mcpManager.getAllTools()` with `getMCPToolsForAgent()` in the SDK MCP server bridge so each agent only sees its own configured MCP tools, preventing cross-agent tool leakage
- **Deferred loading**: enforced searchTools-based discovery gating in the SDK bridge (matching the Vercel AI provider behavior) — non-alwaysLoad tools require discovery before execution, with session metadata pre-seeding
- **Rich output forwarding**: added detection of image/video URLs in tool results and wired them into the streaming state so media chips render in the UI when using the Agent SDK provider

## Test plan

- [ ] Verify agent A cannot call agent B's MCP tools when both are active
- [ ] Verify deferred tools return "requires discovery" message until searchTools activates them
- [ ] Verify previously discovered tools persist across turns via session metadata
- [ ] Verify image/video URLs in MCP tool results show media chips in the UI
- [ ] Verify alwaysLoad tools (searchTools, listAllTools) remain callable without discovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deferred tool loading, allowing MCP tools to be discovered on-demand during conversations.
  * Enabled per-agent tool isolation to prevent cross-agent tool exposure.
  * Introduced rich output support for tool results, enabling improved rendering of images and media in the UI.

* **Improvements**
  * Tool discovery is now persisted across conversation turns for better continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->