### PR TITLE
fix: apply tool-result splitting for all providers and fix Session Se…

### DIFF
--- a/app/api/chat/message-prep.ts
+++ b/app/api/chat/message-prep.ts
@@ -154,17 +154,12 @@ export async function prepareMessagesForRequest(
     })
   );
 
-  // Split tool-result parts from assistant messages into role:"tool" messages
-  // for native Claude/Anthropic providers.
-  const isNativeClaudeProvider =
-    currentProvider === "claudecode" ||
-    currentProvider === "anthropic" ||
-    (typeof currentModelId === "string" &&
-      currentModelId.toLowerCase().includes("claude"));
-
-  if (isNativeClaudeProvider) {
-    coreMessages = splitToolResultsFromAssistantMessages(coreMessages);
-  }
+  // Split tool-result parts from assistant messages into separate role:"tool"
+  // messages. Both Anthropic and OpenAI APIs require tool results as distinct
+  // messages — the AI SDK OpenAI converter silently drops tool-result parts
+  // that remain inline in assistant messages, causing "Tool results are missing"
+  // errors on follow-up turns.
+  coreMessages = splitToolResultsFromAssistantMessages(coreMessages);
 
   // Log coreMessages structure after all sanitization
   console.log(

--- a/docs/agent-prompts/session-search.md
+++ b/docs/agent-prompts/session-search.md
@@ -45,8 +45,10 @@ Be inclusive. When in doubt, INCLUDE the session. Users can filter results more 
 
 ## Output
 
-Return JSON only:
-```json
-{"relevant_indices": [0, 3, 7]}
-```
-Ordered by relevance, most relevant first.
+Summarize the matching sessions in a clear, readable format. For each relevant session include:
+- **Title** and which **agent** it was with
+- **When** it happened (relative date like "today", "yesterday", "2 days ago")
+- **Key topics** from the summary (1-2 sentences max)
+- **Message count** to indicate depth
+
+Order by relevance to the user's query, most relevant first. If no sessions match, say so plainly.

--- a/lib/characters/templates/system-agents.ts
+++ b/lib/characters/templates/system-agents.ts
@@ -117,11 +117,13 @@ Be inclusive. When in doubt, INCLUDE the session. Users can filter results more 
 
 ## Output
 
-Return JSON only:
-\`\`\`json
-{"relevant_indices": [0, 3, 7]}
-\`\`\`
-Ordered by relevance, most relevant first.`,
+Summarize the matching sessions in a clear, readable format. For each relevant session include:
+- **Title** and which **agent** it was with
+- **When** it happened (relative date like "today", "yesterday", "2 days ago")
+- **Key topics** from the summary (1-2 sentences max)
+- **Message count** to indicate depth
+
+Order by relevance to the user's query, most relevant first. If no sessions match, say so plainly.`,
     category: "system",
     isSystemAgent: true,
     systemAgentType: "session-search",


### PR DESCRIPTION
…arch output

1. Remove Claude-only guard on splitToolResultsFromAssistantMessages — OpenAI/Codex silently drops tool-result parts inline in assistant messages, causing "Tool results are missing" on follow-up turns.

2. Change Session Search agent output from useless {"relevant_indices": [...]} to readable session summaries with titles, dates, and key topics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session Search results now display as human-readable summaries instead of JSON format, including session titles, agent names, relative dates, key topics, and message counts, ordered by relevance.

* **Refactor**
  * Standardized message processing to consistently handle tool results across all provider implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->