### PR TITLE
fix: Claude Code tool streaming ordering and dangling tool call sealing

### DIFF
--- a/app/api/sessions/[id]/messages/route.ts
+++ b/app/api/sessions/[id]/messages/route.ts
@@ -1,10 +1,64 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/local-auth";
-import { getSessionWithMessages } from "@/lib/db/queries";
-import { getOrCreateLocalUser } from "@/lib/db/queries";
+import { getSessionWithMessages, updateMessage, getOrCreateLocalUser } from "@/lib/db/queries";
 import { loadSettings } from "@/lib/settings/settings-manager";
 
 type RouteParams = { params: Promise<{ id: string }> };
+
+function sealDanglingToolCallsInContent(
+  content: unknown
+): { content: unknown; changed: boolean } {
+  if (!Array.isArray(content) || content.length === 0) {
+    return { content, changed: false };
+  }
+
+  const parts = content as Array<Record<string, unknown>>;
+  const toolResultIds = new Set<string>();
+
+  for (const part of parts) {
+    if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+      toolResultIds.add(part.toolCallId);
+    }
+  }
+
+  let changed = false;
+  const nextParts: Array<Record<string, unknown>> = [];
+
+  for (const part of parts) {
+    nextParts.push(part);
+    if (part.type !== "tool-call") continue;
+
+    const toolCallId = typeof part.toolCallId === "string" ? part.toolCallId : "";
+    if (!toolCallId || toolResultIds.has(toolCallId)) continue;
+
+    const state = typeof part.state === "string" ? part.state : undefined;
+    if (state !== "input-available" && state !== "input-streaming") continue;
+
+    part.state = "output-error";
+    if (part.args === undefined) {
+      part.args = {};
+    }
+
+    nextParts.push({
+      type: "tool-result",
+      toolCallId,
+      toolName: typeof part.toolName === "string" ? part.toolName : "tool",
+      result: {
+        status: "error",
+        error: "Tool execution ended before a final result was persisted.",
+        reconstructed: true,
+      },
+      status: "error",
+      state: "output-error",
+      timestamp: new Date().toISOString(),
+    });
+
+    toolResultIds.add(toolCallId);
+    changed = true;
+  }
+
+  return changed ? { content: nextParts, changed: true } : { content, changed: false };
+}
 
 /**
  * GET - Fetch all messages for a session
@@ -23,8 +77,22 @@ export async function GET(req: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
+    const repairedMessages = await Promise.all(
+      sessionWithMessages.messages.map(async (message) => {
+        if (message.role !== "assistant") return message;
+        const metadata = (message.metadata ?? {}) as Record<string, unknown>;
+        if (metadata.isStreaming === true) return message;
+
+        const repaired = sealDanglingToolCallsInContent(message.content);
+        if (!repaired.changed) return message;
+
+        await updateMessage(message.id, { content: repaired.content as any });
+        return { ...message, content: repaired.content };
+      })
+    );
+
     return NextResponse.json({
-      messages: sessionWithMessages.messages,
+      messages: repairedMessages,
     });
   } catch (error) {
     console.error("Fetch session messages error:", error);


### PR DESCRIPTION
## Summary
- Fix tool call ordering in Claude Code Agent SDK streaming — tools were arriving out-of-sequence causing UI rendering glitches
- Seal dangling tool calls that remain in `input-streaming` state when the model finishes responding, preventing permanently "loading" tool badges
- Add `streaming-state.ts` module for centralized streaming lifecycle tracking
- Harden `chat-provider.tsx` with proper tool call finalization on stream completion

## Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `app/api/chat/route.ts` | Added streaming state initialization and cleanup |
| 2 | `app/api/chat/stream-callbacks.ts` | Added dangling tool call sealing in onFinish/onAbort |
| 3 | `app/api/chat/streaming-state.ts` | **NEW** — Centralized streaming lifecycle state management |
| 4 | `app/api/sessions/[id]/messages/route.ts` | Enhanced message persistence with tool call state normalization |
| 5 | `components/chat-provider.tsx` | Client-side tool call finalization and ordering fixes |
| 6 | `lib/ai/providers/claudecode-provider.ts` | Major refactor: proper tool streaming event handling, ordering guarantees |

## Test Notes
- Verify tool calls no longer show permanent "loading" spinners after agent completes
- Verify multi-tool responses render in correct order
- Test abort mid-stream — dangling tool calls should be sealed with error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of incomplete tool calls in streaming conversations to ensure proper completion states.
  * Improved error recovery in chat streaming with automatic recovery mechanisms.

* **Improvements**
  * Enhanced streaming message handling for out-of-order events.
  * Refined error logging and message repair in chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->