### PR TITLE
fix localGrep default workspace path resolution

### DIFF
--- a/components/assistant-ui/tool-fallback.tsx
+++ b/components/assistant-ui/tool-fallback.tsx
@@ -532,6 +532,9 @@ const ToolResultDisplay: FC<{ toolName: string; result: ToolResult }> = memo(({ 
       results?: string;
       matches?: Array<{ file: string; line: number; text: string }>;
       searchedPaths?: string[];
+      pathSource?: "explicit" | "workspace" | "synced_folders" | "workspace_then_synced";
+      attemptedScopes?: string[];
+      fallbackUsed?: boolean;
     };
 
     if (grepResult.status === "error") {
@@ -561,6 +564,9 @@ const ToolResultDisplay: FC<{ toolName: string; result: ToolResult }> = memo(({ 
           <p className="text-terminal-dark mb-2">
             {tResults("matchesFound", { count: grepResult.matchCount ?? 0, pattern: grepResult.pattern ?? "" })}
           </p>
+          {grepResult.message && (
+            <p className="text-xs text-terminal-muted mb-2">{grepResult.message}</p>
+          )}
           {grepResult.results && (
             <pre className={cn("mt-2 max-h-64", TOOL_RESULT_PRE_CLASS)}>
               {grepResult.results}

--- a/lib/ai/ripgrep/tool.ts
+++ b/lib/ai/ripgrep/tool.ts
@@ -7,6 +7,8 @@
 
 import { tool, jsonSchema } from "ai";
 import { searchWithRipgrep, isRipgrepAvailable, type RipgrepMatch, type RipgrepSearchResult } from "./ripgrep";
+import { getSession } from "@/lib/db/queries";
+import { getWorkspaceInfo } from "@/lib/workspace/types";
 import { getSyncFolders } from "@/lib/vectordb/sync-service";
 import { validateSyncFolderPath } from "@/lib/vectordb/path-validation";
 import { loadSettings } from "@/lib/settings/settings-manager";
@@ -43,10 +45,101 @@ interface LocalGrepResult {
     pattern?: string;
     regex?: boolean;
     searchedPaths?: string[];
+    /** Where default search paths came from when caller omitted explicit paths */
+    pathSource?: "explicit" | "workspace" | "synced_folders" | "workspace_then_synced";
+    /** Ordered implicit scopes attempted by the tool for no-path requests */
+    attemptedScopes?: string[];
+    /** Whether the tool ran a same-call fallback scope after zero matches */
+    fallbackUsed?: boolean;
     results?: string;
     matches?: Array<{ file: string; line: number; text: string }>;
     message?: string;
     error?: string;
+}
+
+type SyncedPathResolution =
+    | { status: "ok"; paths: string[]; skippedCount: number }
+    | { status: "no_paths"; message: string }
+    | { status: "error"; error: string };
+
+async function resolveSyncedSearchPaths(characterId?: string | null): Promise<SyncedPathResolution> {
+    if (!characterId) {
+        return {
+            status: "no_paths",
+            message: "No paths specified. Please provide paths to search.",
+        };
+    }
+
+    try {
+        const folders = await getSyncFolders(characterId);
+        const validatedFolders = await Promise.all(
+            folders.map(async (folder) => {
+                const { normalizedPath, error } = await validateSyncFolderPath(folder.folderPath, {
+                    requireReadable: false,
+                });
+
+                return {
+                    path: normalizedPath,
+                    error,
+                };
+            })
+        );
+
+        const skippedCount = validatedFolders.filter((folder) => folder.error).length;
+        const paths = validatedFolders
+            .filter((folder) => !folder.error)
+            .map((folder) => folder.path);
+
+        if (paths.length === 0) {
+            return {
+                status: "no_paths",
+                message:
+                    skippedCount > 0
+                        ? "No valid synced folders are currently available for this agent. Synced folder entries may point to deleted or inaccessible paths. Remove stale folders in agent settings or pass explicit paths."
+                        : "No paths specified and no synced folders found for this agent. Please specify paths to search or add synced folders in the agent settings.",
+            };
+        }
+
+        return {
+            status: "ok",
+            paths,
+            skippedCount,
+        };
+    } catch {
+        return {
+            status: "error",
+            error: "Failed to retrieve synced folders. Please specify paths to search explicitly.",
+        };
+    }
+}
+
+async function resolveWorkspaceSearchPath(sessionId: string): Promise<string | null> {
+    if (!sessionId || sessionId === "UNSCOPED") {
+        return null;
+    }
+
+    try {
+        const session = await getSession(sessionId);
+        if (!session) {
+            return null;
+        }
+
+        const metadata = (session.metadata || {}) as Record<string, unknown>;
+        const workspaceInfo = getWorkspaceInfo(metadata);
+        const worktreePath = workspaceInfo?.worktreePath;
+
+        if (!worktreePath || typeof worktreePath !== "string") {
+            return null;
+        }
+
+        const { normalizedPath, error } = await validateSyncFolderPath(worktreePath, {
+            requireReadable: false,
+        });
+
+        return error ? null : normalizedPath;
+    } catch {
+        return null;
+    }
 }
 
 function buildRegexErrorHint(pattern: string, errorMessage: string): string {
@@ -173,7 +266,7 @@ const localGrepSchema = jsonSchema<LocalGrepInput>({
  * Create the localGrep AI tool
  */
 export function createLocalGrepTool(options: LocalGrepToolOptions) {
-    const { characterId } = options;
+    const { sessionId, characterId } = options;
 
     return tool({
         description: `Search for exact text or regex patterns in files using ripgrep.
@@ -310,85 +403,10 @@ Respects .gitignore and skips binary files by default.`,
                 };
             }
 
-            // Determine search paths
-            let searchPaths = paths || [];
-            let skippedSyncedFolderCount = 0;
-
-            if (searchPaths.length === 0 && characterId) {
-                // Default to synced folders for this agent
-                try {
-                    const folders = await getSyncFolders(characterId);
-                    const validatedFolders = await Promise.all(
-                        folders.map(async (folder) => {
-                            const { normalizedPath, error } = await validateSyncFolderPath(folder.folderPath, {
-                                requireReadable: false,
-                            });
-
-                            return {
-                                path: normalizedPath,
-                                error,
-                            };
-                        })
-                    );
-
-                    skippedSyncedFolderCount = validatedFolders.filter((folder) => folder.error).length;
-                    searchPaths = validatedFolders
-                        .filter((folder) => !folder.error)
-                        .map((folder) => folder.path);
-
-                    if (searchPaths.length === 0) {
-                        const message =
-                            skippedSyncedFolderCount > 0
-                                ? "No valid synced folders are currently available for this agent. Synced folder entries may point to deleted or inaccessible paths. Remove stale folders in agent settings or pass explicit paths."
-                                : "No paths specified and no synced folders found for this agent. Please specify paths to search or add synced folders in the agent settings.";
-                        logToolEvent({
-                            level: "warn",
-                            toolName: "localGrep",
-                            event: "error",
-                            error: message,
-                            metadata: { searchPath: "native_localgrep" },
-                        });
-
-                        return {
-                            status: "no_paths",
-                            message,
-                        };
-                    }
-                } catch {
-                    const errorMessage = "Failed to retrieve synced folders. Please specify paths to search explicitly.";
-                    logToolEvent({
-                        level: "error",
-                        toolName: "localGrep",
-                        event: "error",
-                        error: errorMessage,
-                        metadata: { searchPath: "native_localgrep" },
-                    });
-
-                    return {
-                        status: "error",
-                        error: errorMessage,
-                    };
-                }
-            } else if (searchPaths.length === 0) {
-                const message = "No paths specified. Please provide paths to search.";
-                logToolEvent({
-                    level: "warn",
-                    toolName: "localGrep",
-                    event: "error",
-                    error: message,
-                    metadata: { searchPath: "native_localgrep" },
-                });
-
-                return {
-                    status: "no_paths",
-                    message,
-                };
-            }
-
-            try {
-                const searchResult = await searchWithRipgrep({
+            const executeSearch = async (candidatePaths: string[]) => {
+                return searchWithRipgrep({
                     pattern,
-                    paths: searchPaths,
+                    paths: candidatePaths,
                     regex: isRegex,
                     caseInsensitive,
                     maxResults: maxResults ?? settings.localGrepMaxResults ?? 20,
@@ -396,6 +414,107 @@ Respects .gitignore and skips binary files by default.`,
                     contextLines: contextLines ?? settings.localGrepContextLines ?? 2,
                     respectGitignore: settings.localGrepRespectGitignore ?? true,
                 });
+            };
+
+            // Determine search paths
+            const hasExplicitPaths = Array.isArray(paths) && paths.length > 0;
+            let searchPaths = paths || [];
+            let skippedSyncedFolderCount = 0;
+            let pathSource: LocalGrepResult["pathSource"] = hasExplicitPaths ? "explicit" : undefined;
+            const attemptedScopes: string[] = [];
+            let fallbackUsed = false;
+
+            if (!hasExplicitPaths) {
+                const workspacePath = await resolveWorkspaceSearchPath(sessionId);
+                if (workspacePath) {
+                    searchPaths = [workspacePath];
+                    pathSource = "workspace";
+                    attemptedScopes.push("workspace");
+                } else {
+                    attemptedScopes.push("synced_folders");
+                    const syncedResolution = await resolveSyncedSearchPaths(characterId);
+
+                    if (syncedResolution.status === "error") {
+                        logToolEvent({
+                            level: "error",
+                            toolName: "localGrep",
+                            event: "error",
+                            error: syncedResolution.error,
+                            metadata: { searchPath: "native_localgrep" },
+                        });
+
+                        return {
+                            status: "error",
+                            error: syncedResolution.error,
+                        };
+                    }
+
+                    if (syncedResolution.status === "no_paths") {
+                        logToolEvent({
+                            level: "warn",
+                            toolName: "localGrep",
+                            event: "error",
+                            error: syncedResolution.message,
+                            metadata: { searchPath: "native_localgrep" },
+                        });
+
+                        return {
+                            status: "no_paths",
+                            message: syncedResolution.message,
+                        };
+                    }
+
+                    searchPaths = syncedResolution.paths;
+                    skippedSyncedFolderCount = syncedResolution.skippedCount;
+                    pathSource = "synced_folders";
+                }
+            }
+
+            try {
+                let searchResult = await executeSearch(searchPaths);
+                let finalSearchPaths = searchPaths;
+                const infoMessages: string[] = [];
+                let finalPathSource: LocalGrepResult["pathSource"] =
+                    pathSource === "workspace"
+                        ? "workspace"
+                        : pathSource === "synced_folders"
+                            ? "synced_folders"
+                            : pathSource === "explicit"
+                                ? "explicit"
+                                : undefined;
+
+                if (!hasExplicitPaths && pathSource === "workspace" && searchResult.matches.length === 0) {
+                    attemptedScopes.push("synced_folders");
+                    const syncedResolution = await resolveSyncedSearchPaths(characterId);
+
+                    if (syncedResolution.status === "ok") {
+                        skippedSyncedFolderCount += syncedResolution.skippedCount;
+                        fallbackUsed = true;
+                        finalPathSource = "workspace_then_synced";
+                        finalSearchPaths = syncedResolution.paths;
+                        searchResult = await executeSearch(finalSearchPaths);
+                    } else if (syncedResolution.status === "error") {
+                        infoMessages.push(
+                            "Workspace search returned 0 matches; synced folder fallback failed to load."
+                        );
+                    } else {
+                        infoMessages.push(
+                            "Workspace search returned 0 matches; no synced folders were available for fallback."
+                        );
+                    }
+                }
+
+                if (skippedSyncedFolderCount > 0) {
+                    infoMessages.push(
+                        `Skipped ${skippedSyncedFolderCount} unavailable synced folder path(s) before searching.`
+                    );
+                }
+
+                if (fallbackUsed) {
+                    infoMessages.push(
+                        "Workspace search returned 0 matches; retried with synced folders in the same tool call."
+                    );
+                }
 
                 const formattedOutput = formatResults(searchResult, pattern);
 
@@ -409,6 +528,9 @@ Respects .gitignore and skips binary files by default.`,
                         regex: isRegex,
                         matchCount: searchResult.matches.length,
                         skippedSyncedFolderCount,
+                        pathSource: finalPathSource,
+                        attemptedScopes: attemptedScopes.join(","),
+                        fallbackUsed,
                     },
                 });
 
@@ -419,12 +541,12 @@ Respects .gitignore and skips binary files by default.`,
                     wasTruncated: searchResult.wasTruncated,
                     pattern,
                     regex: isRegex,
-                    searchedPaths: searchPaths,
+                    searchedPaths: finalSearchPaths,
+                    pathSource: finalPathSource,
+                    attemptedScopes: attemptedScopes.length > 0 ? attemptedScopes : undefined,
+                    fallbackUsed,
                     results: formattedOutput,
-                    message:
-                        skippedSyncedFolderCount > 0
-                            ? `Skipped ${skippedSyncedFolderCount} unavailable synced folder path(s) before searching.`
-                            : undefined,
+                    message: infoMessages.length > 0 ? infoMessages.join(" ") : undefined,
                     // Also include structured data for potential further processing
                     matches: searchResult.matches.slice(0, 20).map((m: RipgrepMatch) => ({
                         file: m.file,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "test:validate:chat-overflow:dry": "tsx scripts/validation/exec-validation.ts validate-chat-overflow-guards --dry-run",
     "test:validate:tool-errors": "tsx scripts/validation/exec-validation.ts validate-tool-error-auditability",
     "test:validate:tool-errors:dry": "tsx scripts/validation/exec-validation.ts validate-tool-error-auditability --dry-run",
+    "test:validate:localgrep-default-paths": "tsx scripts/validation/validate-localgrep-default-paths.ts",
+    "test:validate:localgrep-default-paths:dry": "tsx scripts/validation/validate-localgrep-default-paths.ts --dry-run",
     "test:validate:mac-signing": "tsx scripts/validation/exec-validation.ts validate-macos-signing-notarization",
     "test:validate:mac-signing:dry": "tsx scripts/validation/exec-validation.ts validate-macos-signing-notarization --dry-run",
     "test:validate:utility-session-token-audit": "tsx scripts/validation/exec-validation.ts validate-utility-session-token-audit",

--- a/scripts/validation/exec-validation.ts
+++ b/scripts/validation/exec-validation.ts
@@ -150,6 +150,7 @@ async function main() {
     console.error("  - validate-message-ordering-migration");
     console.error("  - validate-chat-overflow-guards");
     console.error("  - validate-tool-error-auditability");
+    console.error("  - validate-localgrep-default-paths");
     console.error("  - validate-macos-signing-notarization");
     console.error("  - validate-utility-session-token-audit");
     process.exit(1);

--- a/scripts/validation/validate-localgrep-default-paths.ts
+++ b/scripts/validation/validate-localgrep-default-paths.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env tsx
+/**
+ * Validate localGrep default path handling and workspace fallback contracts.
+ *
+ * Usage:
+ *   npx tsx scripts/validation/validate-localgrep-default-paths.ts --dry-run
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface Check {
+  id: string;
+  description: string;
+  filePath: string;
+  requiredSnippets: string[];
+}
+
+const checks: Check[] = [
+  {
+    id: "workspace-default-resolution",
+    description: "localGrep resolves workspace path from session metadata before synced folders",
+    filePath: "lib/ai/ripgrep/tool.ts",
+    requiredSnippets: [
+      "const workspacePath = await resolveWorkspaceSearchPath(sessionId);",
+      "pathSource = \"workspace\";",
+      "attemptedScopes.push(\"workspace\");",
+    ],
+  },
+  {
+    id: "same-call-fallback",
+    description: "localGrep retries with synced folders in the same call when workspace returns zero matches",
+    filePath: "lib/ai/ripgrep/tool.ts",
+    requiredSnippets: [
+      "if (!hasExplicitPaths && pathSource === \"workspace\" && searchResult.matches.length === 0)",
+      "finalPathSource = \"workspace_then_synced\";",
+      "fallbackUsed = true;",
+    ],
+  },
+  {
+    id: "structured-path-diagnostics",
+    description: "localGrep response exposes path diagnostics for auditing",
+    filePath: "lib/ai/ripgrep/tool.ts",
+    requiredSnippets: [
+      "pathSource: finalPathSource,",
+      "attemptedScopes: attemptedScopes.length > 0 ? attemptedScopes : undefined,",
+      "fallbackUsed,",
+    ],
+  },
+  {
+    id: "ui-success-message-visibility",
+    description: "localGrep success message is rendered in tool fallback UI",
+    filePath: "components/assistant-ui/tool-fallback.tsx",
+    requiredSnippets: [
+      "{grepResult.message && (",
+      "text-terminal-muted",
+    ],
+  },
+  {
+    id: "tests-cover-workspace-defaults",
+    description: "localGrep tests cover workspace-first and fallback-to-synced behavior",
+    filePath: "tests/lib/ai/tools/local-grep-tool.test.ts",
+    requiredSnippets: [
+      "prefers workspace path when no explicit paths are provided",
+      "retries with synced folders in same call when workspace search has zero matches",
+      "pathSource: \"workspace_then_synced\"",
+    ],
+  },
+];
+
+function readUtf8(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+function main(): void {
+  const dryRun = process.argv.includes("--dry-run");
+
+  console.log("\n=== localGrep Default Path Validation ===");
+  console.log(`Mode: ${dryRun ? "dry-run" : "validate"}`);
+  console.log("This validation script is read-only and does not modify files.\n");
+
+  let failed = 0;
+
+  for (const check of checks) {
+    const fileContent = readUtf8(check.filePath);
+    const missing = check.requiredSnippets.filter((snippet) => !fileContent.includes(snippet));
+
+    if (missing.length === 0) {
+      console.log(`PASS ${check.id}`);
+      console.log(`  ${check.description}`);
+      continue;
+    }
+
+    failed += 1;
+    console.error(`FAIL ${check.id}`);
+    console.error(`  ${check.description}`);
+    console.error(`  File: ${check.filePath}`);
+    for (const snippet of missing) {
+      console.error(`  Missing snippet: ${snippet}`);
+    }
+  }
+
+  console.log("\n=== Validation Summary ===");
+  if (failed > 0) {
+    console.error(`Failed checks: ${failed}/${checks.length}`);
+    process.exit(1);
+  }
+
+  console.log(`All checks passed: ${checks.length}/${checks.length}`);
+}
+
+main();

--- a/tests/lib/ai/tools/local-grep-tool.test.ts
+++ b/tests/lib/ai/tools/local-grep-tool.test.ts
@@ -38,12 +38,28 @@ const pathValidationMock = vi.hoisted(() => ({
   validateSyncFolderPath: vi.fn(async (folderPath: string) => ({ normalizedPath: folderPath, error: null })),
 }));
 
+const sessionQueriesMock = vi.hoisted(() => ({
+  getSession: vi.fn(async () => null),
+}));
+
+const workspaceTypesMock = vi.hoisted(() => ({
+  getWorkspaceInfo: vi.fn(() => null),
+}));
+
 vi.mock("@/lib/vectordb/sync-service", () => ({
   getSyncFolders: syncServiceMock.getSyncFolders,
 }));
 
 vi.mock("@/lib/vectordb/path-validation", () => ({
   validateSyncFolderPath: pathValidationMock.validateSyncFolderPath,
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  getSession: sessionQueriesMock.getSession,
+}));
+
+vi.mock("@/lib/workspace/types", () => ({
+  getWorkspaceInfo: workspaceTypesMock.getWorkspaceInfo,
 }));
 
 import { createLocalGrepTool } from "@/lib/ai/ripgrep/tool";
@@ -54,6 +70,8 @@ describe("localGrep tool contract", () => {
     settingsMock.state.settings.localGrepEnabled = true;
     ripgrepMock.isRipgrepAvailable.mockReturnValue(true);
     syncServiceMock.getSyncFolders.mockResolvedValue([]);
+    sessionQueriesMock.getSession.mockResolvedValue(null);
+    workspaceTypesMock.getWorkspaceInfo.mockReturnValue(null);
     pathValidationMock.validateSyncFolderPath.mockImplementation(async (folderPath: string) => ({
       normalizedPath: folderPath,
       error: null,
@@ -161,6 +179,85 @@ describe("localGrep tool contract", () => {
 
     expect(result.status).toBe("no_paths");
     expect(result.message).toContain("No valid synced folders are currently available");
+  });
+
+  it("prefers workspace path when no explicit paths are provided", async () => {
+    sessionQueriesMock.getSession.mockResolvedValue({
+      metadata: { workspaceInfo: { status: "active", worktreePath: "/worktree" } },
+    });
+    workspaceTypesMock.getWorkspaceInfo.mockReturnValue({
+      status: "active",
+      worktreePath: "/worktree",
+    });
+    ripgrepMock.searchWithRipgrep.mockResolvedValue({
+      matches: [{ file: "/worktree/file.ts", line: 1, column: 0, text: "localGrep" }],
+      totalMatches: 1,
+      wasTruncated: false,
+    });
+
+    const tool = createLocalGrepTool({ sessionId: "sess-1", characterId: "char-1" });
+    const result = await tool.execute(
+      { pattern: "localGrep" },
+      { toolCallId: "tc-6", messages: [], abortSignal: new AbortController().signal }
+    );
+
+    expect(result).toMatchObject({
+      status: "success",
+      pathSource: "workspace",
+      searchedPaths: ["/worktree"],
+      fallbackUsed: false,
+      attemptedScopes: ["workspace"],
+    });
+    expect(ripgrepMock.searchWithRipgrep).toHaveBeenCalledTimes(1);
+    expect(ripgrepMock.searchWithRipgrep).toHaveBeenCalledWith(
+      expect.objectContaining({ paths: ["/worktree"] })
+    );
+  });
+
+  it("retries with synced folders in same call when workspace search has zero matches", async () => {
+    sessionQueriesMock.getSession.mockResolvedValue({
+      metadata: { workspaceInfo: { status: "active", worktreePath: "/worktree" } },
+    });
+    workspaceTypesMock.getWorkspaceInfo.mockReturnValue({
+      status: "active",
+      worktreePath: "/worktree",
+    });
+    syncServiceMock.getSyncFolders.mockResolvedValue([{ folderPath: "/repo" }]);
+
+    ripgrepMock.searchWithRipgrep
+      .mockResolvedValueOnce({
+        matches: [],
+        totalMatches: 0,
+        wasTruncated: false,
+      })
+      .mockResolvedValueOnce({
+        matches: [{ file: "/repo/file.ts", line: 1, column: 0, text: "localGrep" }],
+        totalMatches: 1,
+        wasTruncated: false,
+      });
+
+    const tool = createLocalGrepTool({ sessionId: "sess-1", characterId: "char-1" });
+    const result = await tool.execute(
+      { pattern: "localGrep" },
+      { toolCallId: "tc-7", messages: [], abortSignal: new AbortController().signal }
+    );
+
+    expect(result).toMatchObject({
+      status: "success",
+      pathSource: "workspace_then_synced",
+      searchedPaths: ["/repo"],
+      fallbackUsed: true,
+      attemptedScopes: ["workspace", "synced_folders"],
+    });
+    expect(result.message).toContain("retried with synced folders");
+    expect(ripgrepMock.searchWithRipgrep).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ paths: ["/worktree"] })
+    );
+    expect(ripgrepMock.searchWithRipgrep).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ paths: ["/repo"] })
+    );
   });
 
   it("adds a regex-specific hint when regex parse fails", async () => {


### PR DESCRIPTION
## Summary
- make `localGrep` default path resolution workspace-aware using session `workspaceInfo`
- add same-call fallback from workspace path to synced folders when workspace search returns zero matches
- expose structured diagnostics (`pathSource`, `attemptedScopes`, `fallbackUsed`) and surface success messages in tool fallback UI
- add dry-run validation script for this behavior and wire it into validation discovery/scripts
- extend unit tests with workspace-first and workspace->synced fallback coverage

## Files Changed
| # | Issue | Files | Change |
|---|---|---|---|
| 1 | localGrep no-path calls waste retries before path correction | `lib/ai/ripgrep/tool.ts` | Added workspace-first implicit path resolution via session metadata, same-call fallback to synced folders on zero matches, and response/log diagnostics fields |
| 2 | localGrep success context not visible in UI | `components/assistant-ui/tool-fallback.tsx` | Rendered `grepResult.message` on success to expose fallback/skip context |
| 3 | Missing regression coverage for workspace-aware localGrep defaults | `tests/lib/ai/tools/local-grep-tool.test.ts` | Added mocks and tests for workspace-first pathing and same-call synced fallback |
| 4 | Need dry-run validator for this contract | `scripts/validation/validate-localgrep-default-paths.ts`, `scripts/validation/exec-validation.ts`, `package.json` | Added standalone read-only validator and npm scripts/help listing |

## Test Notes
- `npm run typecheck` ✅
- `npm run test:run -- tests/lib/ai/tools/local-grep-tool.test.ts` ✅
- `npm run test:validate:localgrep-default-paths:dry` ✅