### PR TITLE
fix: persist tiptap editor mode and draft across navigation

### DIFF
--- a/components/assistant-ui/thread-composer.tsx
+++ b/components/assistant-ui/thread-composer.tsx
@@ -8,6 +8,7 @@ import {
   useThreadRuntime,
   useThreadComposer,
 } from "@assistant-ui/react";
+import type { JSONContent } from "@tiptap/core";
 import {
   ClockIcon,
   XIcon,
@@ -29,6 +30,7 @@ import { ZLUTTY_EASINGS, ZLUTTY_DURATIONS } from "@/lib/animations/utils";
 import { useTranslations } from "next-intl";
 import { useMCPReloadStatus } from "@/hooks/use-mcp-reload-status";
 import { useSessionComposerDraft } from "@/lib/hooks/use-session-composer-draft";
+import { useSessionComposerEditorState } from "@/lib/hooks/use-session-composer-editor-state";
 import { ContextWindowIndicator } from "./context-window-indicator";
 import { ActiveModelIndicator } from "./active-model-indicator";
 import { ActiveDelegationsIndicator } from "./active-delegations-indicator";
@@ -93,7 +95,6 @@ export const Composer: FC<{
   const tiptapRef = useRef<TiptapEditorHandle>(null);
   const prefersReducedMotion = useReducedMotion();
 
-  const [isEditorMode, setIsEditorMode] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 
   // Attempt to inject a message into the currently active run's live prompt queue.
@@ -147,6 +148,13 @@ export const Composer: FC<{
     restoredSelection,
     clearDraft,
   } = useSessionComposerDraft(sessionId);
+  const {
+    isEditorMode,
+    setIsEditorMode,
+    tiptapDraft,
+    setTiptapDraft,
+    clearTiptapDraft,
+  } = useSessionComposerEditorState(sessionId);
 
   const updateCursorPosition = useCallback(
     (selectionStart: number, selectionEnd: number = selectionStart) => {
@@ -385,6 +393,7 @@ export const Composer: FC<{
           deepResearch.startResearch(textOnly.trim());
         }
         tiptapRef.current?.clear();
+        clearTiptapDraft();
         return;
       }
 
@@ -425,6 +434,7 @@ export const Composer: FC<{
           ]);
         }
         tiptapRef.current?.clear();
+        clearTiptapDraft();
         return;
       }
 
@@ -435,6 +445,7 @@ export const Composer: FC<{
       });
 
       tiptapRef.current?.clear();
+      clearTiptapDraft();
       clearEnhancement();
     },
     [
@@ -443,12 +454,24 @@ export const Composer: FC<{
       deepResearch,
       threadRuntime,
       clearEnhancement,
+      clearTiptapDraft,
     ]
   );
 
   const toggleEditorMode = useCallback(() => {
     setIsEditorMode((prev) => !prev);
-  }, []);
+  }, [setIsEditorMode]);
+
+  const handleTiptapDraftChange = useCallback(
+    (nextDraft: JSONContent | null) => {
+      setTiptapDraft(nextDraft);
+    },
+    [setTiptapDraft],
+  );
+
+  const handleClearTiptapDraft = useCallback(() => {
+    clearTiptapDraft();
+  }, [clearTiptapDraft]);
 
   const handleInsertMention = useCallback(
     (mention: string, atIndex: number, queryLength: number) => {
@@ -822,6 +845,9 @@ export const Composer: FC<{
               placeholder={getPlaceholder()}
               disabled={isDeepResearchLoading}
               isSubmitting={false}
+              initialContent={tiptapDraft}
+              onDraftChange={handleTiptapDraftChange}
+              onDraftClear={handleClearTiptapDraft}
             />
             <div className="flex items-center justify-end">
               <ComposerActionBar

--- a/components/assistant-ui/tiptap-editor.tsx
+++ b/components/assistant-ui/tiptap-editor.tsx
@@ -9,6 +9,7 @@ import {
   useImperativeHandle,
 } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
+import type { JSONContent } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -60,6 +61,12 @@ interface TiptapEditorProps {
   onSubmit: (content: ContentPart[]) => void;
   /** Session ID for image uploads */
   sessionId?: string;
+  /** Initial editor document, restored from draft persistence */
+  initialContent?: JSONContent | null;
+  /** Called whenever editor doc changes */
+  onDraftChange?: (draft: JSONContent | null) => void;
+  /** Called after editor content is cleared */
+  onDraftClear?: () => void;
   /** Placeholder text */
   placeholder?: string;
   /** Whether submission is disabled */
@@ -233,6 +240,9 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
       disabled = false,
       isSubmitting = false,
       className,
+      initialContent = null,
+      onDraftChange,
+      onDraftClear,
     },
     ref,
   ) => {
@@ -240,6 +250,10 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
     const [isUploading, setIsUploading] = useState(false);
 
     const editor = useEditor({
+      content: initialContent ?? undefined,
+      onUpdate: ({ editor: currentEditor }) => {
+        onDraftChange?.(currentEditor.isEmpty ? null : currentEditor.getJSON());
+      },
       extensions: [
         StarterKit.configure({
           heading: { levels: [2, 3] },
@@ -438,6 +452,7 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
       },
       clear: () => {
         editor?.commands.clearContent();
+        onDraftClear?.();
       },
       focus: () => {
         editor?.commands.focus();

--- a/lib/hooks/use-session-composer-editor-state.ts
+++ b/lib/hooks/use-session-composer-editor-state.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { JSONContent } from "@tiptap/core";
+
+const COMPOSER_EDITOR_MODE_STORAGE_PREFIX = "seline:composer-editor-mode";
+const COMPOSER_TIPTAP_DRAFT_STORAGE_PREFIX = "seline:composer-tiptap-draft";
+
+const inMemoryEditorModeCache = new Map<string, boolean>();
+const inMemoryTiptapDraftCache = new Map<string, JSONContent | null>();
+
+function resolveStorageKey(prefix: string, sessionId?: string | null): string {
+  const normalizedSessionId = typeof sessionId === "string" ? sessionId.trim() : "";
+  return `${prefix}:${normalizedSessionId || "default"}`;
+}
+
+function readEditorMode(storageKey: string): boolean {
+  const cached = inMemoryEditorModeCache.get(storageKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const rawValue = window.sessionStorage.getItem(storageKey);
+    const value = rawValue === "true";
+    inMemoryEditorModeCache.set(storageKey, value);
+    return value;
+  } catch {
+    return false;
+  }
+}
+
+function persistEditorMode(storageKey: string, isEditorMode: boolean): void {
+  inMemoryEditorModeCache.set(storageKey, isEditorMode);
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (!isEditorMode) {
+      window.sessionStorage.removeItem(storageKey);
+      return;
+    }
+    window.sessionStorage.setItem(storageKey, "true");
+  } catch {
+    // Ignore storage failures and keep in-memory fallback.
+  }
+}
+
+function readTiptapDraft(storageKey: string): JSONContent | null {
+  const cached = inMemoryTiptapDraftCache.get(storageKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const rawValue = window.sessionStorage.getItem(storageKey);
+    if (!rawValue) {
+      inMemoryTiptapDraftCache.set(storageKey, null);
+      return null;
+    }
+
+    const parsed = JSON.parse(rawValue) as JSONContent;
+    if (!parsed || typeof parsed !== "object") {
+      inMemoryTiptapDraftCache.set(storageKey, null);
+      return null;
+    }
+
+    inMemoryTiptapDraftCache.set(storageKey, parsed);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function persistTiptapDraft(storageKey: string, draft: JSONContent | null): void {
+  inMemoryTiptapDraftCache.set(storageKey, draft);
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (draft === null) {
+      window.sessionStorage.removeItem(storageKey);
+      return;
+    }
+    window.sessionStorage.setItem(storageKey, JSON.stringify(draft));
+  } catch {
+    // Ignore storage failures and keep in-memory fallback.
+  }
+}
+
+export function useSessionComposerEditorState(sessionId?: string | null) {
+  const editorModeStorageKey = useMemo(
+    () => resolveStorageKey(COMPOSER_EDITOR_MODE_STORAGE_PREFIX, sessionId),
+    [sessionId],
+  );
+  const tiptapDraftStorageKey = useMemo(
+    () => resolveStorageKey(COMPOSER_TIPTAP_DRAFT_STORAGE_PREFIX, sessionId),
+    [sessionId],
+  );
+
+  const editorModeStorageKeyRef = useRef(editorModeStorageKey);
+  const tiptapDraftStorageKeyRef = useRef(tiptapDraftStorageKey);
+
+  const [isEditorMode, setIsEditorModeState] = useState<boolean>(() => readEditorMode(editorModeStorageKey));
+  const [tiptapDraft, setTiptapDraftState] = useState<JSONContent | null>(() => readTiptapDraft(tiptapDraftStorageKey));
+
+  useEffect(() => {
+    editorModeStorageKeyRef.current = editorModeStorageKey;
+    setIsEditorModeState(readEditorMode(editorModeStorageKey));
+  }, [editorModeStorageKey]);
+
+  useEffect(() => {
+    tiptapDraftStorageKeyRef.current = tiptapDraftStorageKey;
+    setTiptapDraftState(readTiptapDraft(tiptapDraftStorageKey));
+  }, [tiptapDraftStorageKey]);
+
+  const setIsEditorMode = useCallback(
+    (value: boolean | ((previous: boolean) => boolean)) => {
+      setIsEditorModeState((previous) => {
+        const nextValue = typeof value === "function" ? value(previous) : value;
+        persistEditorMode(editorModeStorageKeyRef.current, nextValue);
+        return nextValue;
+      });
+    },
+    [],
+  );
+
+  const setTiptapDraft = useCallback(
+    (
+      value:
+        | JSONContent
+        | null
+        | ((previous: JSONContent | null) => JSONContent | null),
+    ) => {
+      setTiptapDraftState((previous) => {
+        const nextValue = typeof value === "function" ? value(previous) : value;
+        persistTiptapDraft(tiptapDraftStorageKeyRef.current, nextValue);
+        return nextValue;
+      });
+    },
+    [],
+  );
+
+  const clearTiptapDraft = useCallback(() => {
+    setTiptapDraft(null);
+  }, [setTiptapDraft]);
+
+  return {
+    isEditorMode,
+    setIsEditorMode,
+    tiptapDraft,
+    setTiptapDraft,
+    clearTiptapDraft,
+  };
+}


### PR DESCRIPTION
## Summary
- persist composer editor mode (`isEditorMode`) per session across unmount/remount
- persist Tiptap JSON draft content per session with sessionStorage + in-memory fallback
- wire `thread-composer` and `tiptap-editor` to restore, update, and clear rich draft state atomically

## Files Changed
| # | Issue | Files | Change |
|---|---|---|---|
| 1 | Editor mode toggle resets to textarea on navigation | `components/assistant-ui/thread-composer.tsx`, `lib/hooks/use-session-composer-editor-state.ts` | Replaced ephemeral `useState(false)` mode flag with persisted session-scoped editor state hook |
| 2 | Tiptap content destroyed on unmount/remount | `components/assistant-ui/tiptap-editor.tsx`, `lib/hooks/use-session-composer-editor-state.ts` | Added `initialContent`, `onDraftChange`, `onDraftClear` props and wired `useEditor` content/onUpdate persistence |
| 3 | Draft remains after send/queue/deep-research submit paths | `components/assistant-ui/thread-composer.tsx` | Cleared persisted Tiptap draft in all clear paths where editor content is reset |

## Test Notes
- npm run typecheck
- npm run test