### PR TITLE
feat(dario): add Dario Claude Code auth provider with full integration

### DIFF
--- a/app/api/auth/claudecode/authorize/route.ts
+++ b/app/api/auth/claudecode/authorize/route.ts
@@ -1,14 +1,20 @@
 import { NextResponse } from "next/server";
-import { getClaudeCodeAuthStatus } from "@/lib/auth/claudecode-auth";
-import { startClaudeLogin } from "@/lib/ai/providers/cliproxy/login";
+import {
+  getClaudeCodeAuthStatus,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
+} from "@/lib/auth/claudecode-auth";
+import {
+  isSuccessfulClaudeLoginOutput,
+  startClaudeLogin,
+} from "@/lib/ai/providers/dario/login";
 
 /**
  * GET /api/auth/claudecode/authorize
  *
- * If the sidecar already has a credential on file, short-circuits with
- * `authenticated: true`. Otherwise spawns `cliproxyapi -claude-login` and
- * returns the OAuth URL for the UI to open in a browser. The OAuth callback
- * fires automatically into the sidecar — there's no code-paste step.
+ * If Dario already has usable Claude credentials, short-circuits with
+ * `authenticated: true`. Otherwise starts `dario login --manual --no-proxy`
+ * and returns the OAuth URL for the UI to open. The UI posts the pasted code
+ * to /exchange, which writes it to the active Dario login subprocess.
  */
 export async function GET() {
   try {
@@ -17,11 +23,59 @@ export async function GET() {
       return NextResponse.json({
         success: true,
         authenticated: true,
-        message: "Claude Code is already authenticated",
+        message: "Claude Code is already authenticated through Dario",
       });
     }
 
     const { url, output } = await startClaudeLogin();
+
+    // `dario login --manual --no-proxy` can complete without printing an OAuth
+    // URL when existing credentials are valid or only needed a refresh. Treat
+    // Dario's success output as a reason to verify the sidecar immediately, not
+    // as a reason to ask the user for a nonexistent manual code.
+    if (!url) {
+      if (isSuccessfulClaudeLoginOutput(output)) {
+        const verified = await verifyClaudeCodeAuthenticatedAfterDarioLogin(output);
+        if (verified.authenticated) {
+          return NextResponse.json({
+            success: true,
+            authenticated: true,
+            output,
+            message: "Claude Code credentials are available through Dario",
+          });
+        }
+
+        return NextResponse.json(
+          {
+            success: false,
+            authenticated: false,
+            output,
+            error: verified.error ?? "Dario credentials were found, but Selene could not verify the local Dario sidecar.",
+          },
+          { status: 502 },
+        );
+      }
+
+      const refreshedStatus = await getClaudeCodeAuthStatus();
+      if (refreshedStatus.authenticated) {
+        return NextResponse.json({
+          success: true,
+          authenticated: true,
+          output,
+          message: "Claude Code credentials were refreshed through Dario",
+        });
+      }
+
+      return NextResponse.json(
+        {
+          success: false,
+          authenticated: false,
+          output,
+          error: "Dario did not return an authentication URL or verified credentials.",
+        },
+        { status: 502 },
+      );
+    }
 
     return NextResponse.json({
       success: true,
@@ -29,8 +83,8 @@ export async function GET() {
       url: url ?? null,
       output,
       message: url
-        ? "Open the provided URL to authenticate; this dialog will refresh when the OAuth callback completes."
-        : "Could not detect the OAuth URL — check that the CLIProxyAPI sidecar is installed.",
+        ? "Open the provided URL to authenticate, then paste the Claude code shown by the browser."
+        : "Dario did not print an OAuth URL. Check the diagnostic output and try again.",
     });
   } catch (error) {
     console.error("[ClaudeCodeAuthorize] Failed:", error);

--- a/app/api/auth/claudecode/exchange/route.ts
+++ b/app/api/auth/claudecode/exchange/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { getClaudeCodeAuthStatus } from "@/lib/auth/claudecode-auth";
+import {
+  getClaudeCodeAuthStatus,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
+} from "@/lib/auth/claudecode-auth";
 import {
   awaitClaudeLoginCompletion,
   getClaudeLoginState,
@@ -13,6 +16,12 @@ import {
  * subprocess, waits briefly for Dario to persist credentials, then returns the
  * refreshed Dario auth status. Idempotent when already authenticated.
  */
+function claudeCodeExchangeErrorStatus(message: string): number {
+  if (/No active Dario OAuth login/i.test(message)) return 409;
+  if (/Paste the authorization code/i.test(message)) return 400;
+  return 500;
+}
+
 export async function POST(request: Request) {
   try {
     const before = await getClaudeCodeAuthStatus();
@@ -42,22 +51,23 @@ export async function POST(request: Request) {
     submitClaudeLoginCode(code);
 
     const final = await awaitClaudeLoginCompletion(30_000);
-    const after = await getClaudeCodeAuthStatus();
+    const after = await verifyClaudeCodeAuthenticatedAfterDarioLogin(final?.output ?? []);
 
     return NextResponse.json({
       success: after.authenticated,
       authenticated: after.authenticated,
       error: after.authenticated
         ? undefined
-        : final?.errorMessage ?? after.error ?? "OAuth flow did not complete in time. Try again.",
-      output: final?.output ?? after.output,
+        : after.error ?? final?.errorMessage ?? "OAuth flow did not complete in time. Try again.",
+      output: after.output ?? final?.output,
       url: final?.url ?? after.authUrl ?? null,
     });
   } catch (error) {
     console.error("[ClaudeCodeExchange] Error:", error);
+    const message = error instanceof Error ? error.message : "Failed to verify authentication status";
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : "Failed to verify authentication status" },
-      { status: 500 },
+      { success: false, authenticated: false, error: message },
+      { status: claudeCodeExchangeErrorStatus(message) },
     );
   }
 }

--- a/app/api/auth/claudecode/exchange/route.ts
+++ b/app/api/auth/claudecode/exchange/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse } from "next/server";
 import { getClaudeCodeAuthStatus } from "@/lib/auth/claudecode-auth";
-import { awaitClaudeLoginCompletion, getClaudeLoginState } from "@/lib/ai/providers/cliproxy/login";
+import {
+  awaitClaudeLoginCompletion,
+  getClaudeLoginState,
+  submitClaudeLoginCode,
+} from "@/lib/ai/providers/dario/login";
 
 /**
  * POST /api/auth/claudecode/exchange
  *
- * Blocks (up to ~30s) waiting for the OAuth browser callback to complete
- * into the active `cliproxyapi -claude-login` subprocess, then returns the
- * resulting auth status. Idempotent — if no login session is in flight and a
- * credential already exists, returns the cached state.
- *
- * The body shape `{ code }` is accepted for backwards compatibility with the
- * old Agent-SDK paste flow but the field is ignored — CLIProxyAPI's local
- * HTTP callback collects the code itself.
+ * Writes the pasted Claude OAuth code to the active `dario login --manual`
+ * subprocess, waits briefly for Dario to persist credentials, then returns the
+ * refreshed Dario auth status. Idempotent when already authenticated.
  */
-export async function POST() {
+export async function POST(request: Request) {
   try {
     const before = await getClaudeCodeAuthStatus();
     if (before.authenticated) {
@@ -32,11 +31,15 @@ export async function POST() {
           success: false,
           authenticated: false,
           error:
-            "No active OAuth login. Click 'Login with Claude' to start a new flow.",
+            "No active Dario OAuth login. Click 'Login with Claude' to start a new flow.",
         },
         { status: 409 },
       );
     }
+
+    const body = await request.json().catch(() => ({}));
+    const code = typeof body?.code === "string" ? body.code : "";
+    submitClaudeLoginCode(code);
 
     const final = await awaitClaudeLoginCompletion(30_000);
     const after = await getClaudeCodeAuthStatus();
@@ -46,14 +49,14 @@ export async function POST() {
       authenticated: after.authenticated,
       error: after.authenticated
         ? undefined
-        : final?.errorMessage ?? "OAuth flow did not complete in time. Try again.",
+        : final?.errorMessage ?? after.error ?? "OAuth flow did not complete in time. Try again.",
       output: final?.output ?? after.output,
       url: final?.url ?? after.authUrl ?? null,
     });
   } catch (error) {
     console.error("[ClaudeCodeExchange] Error:", error);
     return NextResponse.json(
-      { success: false, error: "Failed to verify authentication status" },
+      { success: false, error: error instanceof Error ? error.message : "Failed to verify authentication status" },
       { status: 500 },
     );
   }

--- a/app/api/auth/claudecode/refresh/route.ts
+++ b/app/api/auth/claudecode/refresh/route.ts
@@ -1,25 +1,26 @@
 import { NextResponse } from "next/server";
 import { getClaudeCodeAuthStatus } from "@/lib/auth/claudecode-auth";
-import { killClaudeLogin } from "@/lib/ai/providers/cliproxy/login";
+import { killClaudeLogin, refreshClaudeLogin } from "@/lib/ai/providers/dario/login";
 
 /**
  * POST /api/auth/claudecode/refresh
  *
- * Cancels any pending login subprocess and re-reads the sidecar credential
- * dir to produce a fresh status snapshot.
+ * Cancels any pending Dario login subprocess, asks Dario to refresh OAuth if it
+ * can, then re-reads the Dario status endpoint for a fresh UI snapshot.
  */
 export async function POST() {
   try {
     killClaudeLogin();
+    const refresh = await refreshClaudeLogin();
     const status = await getClaudeCodeAuthStatus();
 
     return NextResponse.json({
       refreshed: status.authenticated,
       authenticated: status.authenticated,
       reason: status.authenticated ? "authenticated" : "not_authenticated",
-      output: status.output,
+      output: status.output ?? refresh.output,
       url: status.authUrl ?? null,
-      error: status.error,
+      error: status.error ?? refresh.errorMessage,
     });
   } catch (error) {
     console.error("[ClaudeCodeRefresh] Error:", error);

--- a/app/api/auth/claudecode/route.ts
+++ b/app/api/auth/claudecode/route.ts
@@ -58,7 +58,7 @@ export async function POST() {
     {
       success: false,
       error:
-        "Manual token submission is disabled. Start OAuth via /api/auth/claudecode/authorize.",
+        "Direct token submission is disabled. Start Dario OAuth via /api/auth/claudecode/authorize.",
     },
     { status: 410 },
   );

--- a/app/settings/claude-code-auth-flow.tsx
+++ b/app/settings/claude-code-auth-flow.tsx
@@ -70,13 +70,13 @@ export function ClaudeCodeAuthFlow({
           <div className="space-y-2">
             <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-900/20">
               <p className="font-mono text-xs text-amber-700 dark:text-amber-400">
-                {"Dario did not return an authentication URL. Review the diagnostic output below, then retry Claude Code authentication."}
+                {t("noAuthUrl") || "Dario did not return an authentication URL. Review the diagnostic output below, then retry Claude Code authentication."}
               </p>
             </div>
             {diagnosticOutput && diagnosticOutput.length > 0 && (
               <details className="rounded border border-terminal-border">
                 <summary className="cursor-pointer px-3 py-1.5 font-mono text-xs text-terminal-muted">
-                  Diagnostic details
+                  {t("diagnosticDetails") || "Diagnostic details"}
                 </summary>
                 <pre className="max-h-24 overflow-auto px-3 py-2 font-mono text-[10px] text-terminal-muted">
                   {diagnosticOutput.join("\n")}

--- a/app/settings/claude-code-auth-flow.tsx
+++ b/app/settings/claude-code-auth-flow.tsx
@@ -70,9 +70,7 @@ export function ClaudeCodeAuthFlow({
           <div className="space-y-2">
             <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-900/20">
               <p className="font-mono text-xs text-amber-700 dark:text-amber-400">
-                {"Could not open the authentication page automatically. Run "}
-                <code className="rounded bg-amber-100 px-1 py-0.5 dark:bg-amber-800/40">claude login</code>
-                {" in your terminal, then paste the authorization code below."}
+                {"Dario did not return an authentication URL. Review the diagnostic output below, then retry Claude Code authentication."}
               </p>
             </div>
             {diagnosticOutput && diagnosticOutput.length > 0 && (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -426,6 +426,17 @@ export default function SettingsPage() {
         throw new Error(authData.error || t("errors.authUrlFailed"));
       }
 
+      if (authData.authenticated) {
+        const authenticated = await loadClaudeCodeAuth({ forceRefresh: true });
+        if (!authenticated) {
+          throw new Error(t("errors.authStartFailed"));
+        }
+        setClaudeCodeAuthSuccess(true);
+        setClaudeCodePasteMode(true);
+        setClaudecodeLoading(false);
+        return;
+      }
+
       if (authData.url) {
         if (isElectron && electronAPI?.shell?.openExternal) {
           await electronAPI.shell.openExternal(authData.url);
@@ -438,7 +449,7 @@ export default function SettingsPage() {
         setClaudeCodeDiagnosticOutput(authData.output || []);
       }
 
-      // Show the verification panel while auth is completed via Agent SDK.
+      // Show the verification panel while auth is completed through Dario.
       setClaudeCodePasteMode(true);
       setClaudecodeLoading(false);
     } catch (err) {

--- a/components/onboarding/steps/auth-step.tsx
+++ b/components/onboarding/steps/auth-step.tsx
@@ -265,7 +265,7 @@ export function AuthStep({ provider, onAuthenticated, onBack, onSkip }: AuthStep
         const isElectron = !!electronAPI?.isElectron;
 
         try {
-            // Plain fetch — no timeout. The authorize endpoint spawns `claude login`
+            // Plain fetch — no timeout. The authorize endpoint spawns `dario login`
             // which can take well over 10s on first run; resilientFetch's default
             // 10s timeout would abort the request prematurely.
             const authResponse = await fetch("/api/auth/claudecode/authorize");
@@ -629,9 +629,7 @@ export function AuthStep({ provider, onAuthenticated, onBack, onSkip }: AuthStep
                                     ) : (
                                         <div className="rounded-lg border border-amber-300 bg-amber-50 p-3">
                                             <p className="text-sm text-amber-700 font-mono">
-                                                {"Could not open authentication page automatically. Run "}
-                                                <code className="rounded bg-amber-100 px-1 py-0.5">claude login</code>
-                                                {" in your terminal, then paste the authorization code below."}
+                                                {"Dario did not return an authentication URL. Retry Claude Code authentication from Settings if this persists."}
                                             </p>
                                         </div>
                                     )}

--- a/components/onboarding/steps/auth-step.tsx
+++ b/components/onboarding/steps/auth-step.tsx
@@ -629,7 +629,7 @@ export function AuthStep({ provider, onAuthenticated, onBack, onSkip }: AuthStep
                                     ) : (
                                         <div className="rounded-lg border border-amber-300 bg-amber-50 p-3">
                                             <p className="text-sm text-amber-700 font-mono">
-                                                {"Dario did not return an authentication URL. Retry Claude Code authentication from Settings if this persists."}
+                                                {t("noAuthUrl")}
                                             </p>
                                         </div>
                                     )}

--- a/lib/ai/providers/claudecode-client.ts
+++ b/lib/ai/providers/claudecode-client.ts
@@ -35,10 +35,10 @@ function createSidecarFetch(): typeof fetch {
 }
 
 function buildProvider(): AnthropicProvider {
-  const { apiKey, port } = ensureDarioConfig();
+  const { apiKey, port, host } = ensureDarioConfig();
   return createAnthropic({
     apiKey,
-    baseURL: getDarioBaseUrl(port),
+    baseURL: getDarioBaseUrl(port, host),
     fetch: createSidecarFetch(),
   });
 }

--- a/lib/ai/providers/claudecode-client.ts
+++ b/lib/ai/providers/claudecode-client.ts
@@ -1,8 +1,8 @@
 /**
  * Claude Code provider — talks Anthropic Messages protocol over the
- * CLIProxyAPI sidecar.
+ * Dario sidecar.
  *
- * The sidecar is the OAuth-bearing process; this module is a thin
+ * Dario is the OAuth-bearing local proxy; this module is a thin
  * `createAnthropic` wrapper that points at `http://127.0.0.1:<port>/v1` and
  * lets the existing AI SDK plumbing (streaming, tool_use, caching headers)
  * handle the rest.
@@ -14,8 +14,8 @@
 
 import { createAnthropic } from "@ai-sdk/anthropic";
 import type { LanguageModel } from "ai";
-import { ensureCliproxyConfig, getCliproxyBaseUrl } from "./cliproxy/config";
-import { ensureSidecarReady } from "./cliproxy/sidecar";
+import { ensureDarioConfig, getDarioBaseUrl } from "./dario/config";
+import { ensureDarioSidecarReady } from "./dario/sidecar";
 
 type AnthropicProvider = ReturnType<typeof createAnthropic>;
 
@@ -24,21 +24,21 @@ let cached: AnthropicProvider | null = null;
 /**
  * A `fetch` that ensures the sidecar is up before every request.
  *
- * When the sidecar is already healthy this is a single in-process check;
+ * When the sidecar is already listening this is a single in-process check;
  * when it has died, the first request pays the spawn-and-poll cost.
  */
 function createSidecarFetch(): typeof fetch {
   return async (input, init) => {
-    await ensureSidecarReady();
+    await ensureDarioSidecarReady();
     return globalThis.fetch(input, init);
   };
 }
 
 function buildProvider(): AnthropicProvider {
-  const { apiKey, port } = ensureCliproxyConfig();
+  const { apiKey, port } = ensureDarioConfig();
   return createAnthropic({
     apiKey,
-    baseURL: getCliproxyBaseUrl(port),
+    baseURL: getDarioBaseUrl(port),
     fetch: createSidecarFetch(),
   });
 }

--- a/lib/ai/providers/dario/binary.ts
+++ b/lib/ai/providers/dario/binary.ts
@@ -1,0 +1,122 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+export type DarioCommandSource = "override" | "packaged" | "dependency" | "external" | "path";
+
+export interface DarioCommandResolution {
+  command: string;
+  argsPrefix: string[];
+  source: DarioCommandSource;
+  description: string;
+}
+
+function nodeExecutableName(): string {
+  return process.platform === "win32" ? "node.exe" : "node";
+}
+
+function getElectronResourcesPath(): string | null {
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    || process.env.ELECTRON_RESOURCES_PATH
+    || null;
+  return resourcesPath && resourcesPath.trim().length > 0 ? resourcesPath : null;
+}
+
+function firstExisting(candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function resolveWorkspaceDarioCli(): { cliPath: string; source: "dependency" | "external" } | null {
+  const cwd = process.cwd();
+  const candidates: Array<{ cliPath: string; source: "dependency" | "external" }> = [
+    {
+      cliPath: resolve(cwd, "node_modules", "@askalf", "dario", "dist", "cli.js"),
+      source: "dependency",
+    },
+    {
+      cliPath: resolve(cwd, ".external", "dario", "dist", "cli.js"),
+      source: "external",
+    },
+    {
+      cliPath: resolve(dirname(process.execPath), "..", "lib", "node_modules", "@askalf", "dario", "dist", "cli.js"),
+      source: "dependency",
+    },
+  ];
+
+  return candidates.find((candidate) => existsSync(candidate.cliPath)) ?? null;
+}
+
+/**
+ * Resolve the Dario CLI without relying on the host PATH in packaged builds.
+ *
+ * Electron runs the Next.js server in a utility process with
+ * ELECTRON_RESOURCES_PATH pointing at the app's Resources directory. The Dario
+ * npm package is copied into standalone/node_modules during electron:prepare,
+ * and the bundled Node binary lives beside it in standalone/node_modules/.bin.
+ */
+export function resolveDarioCommand(): DarioCommandResolution {
+  const override = process.env.SELENE_DARIO_BIN?.trim();
+  if (override) {
+    return {
+      command: override,
+      argsPrefix: [],
+      source: "override",
+      description: override,
+    };
+  }
+
+  const resourcesPath = getElectronResourcesPath();
+  const isPackaged = !!resourcesPath && process.env.ELECTRON_IS_DEV !== "1";
+  if (isPackaged) {
+    const cliPath = join(resourcesPath, "standalone", "node_modules", "@askalf", "dario", "dist", "cli.js");
+    const nodePath = join(resourcesPath, "standalone", "node_modules", ".bin", nodeExecutableName());
+    const missing = [
+      existsSync(cliPath) ? null : cliPath,
+      existsSync(nodePath) ? null : nodePath,
+    ].filter((path): path is string => Boolean(path));
+
+    if (missing.length > 0) {
+      throw new Error(
+        "Bundled Dario runtime is missing from the packaged app: "
+        + `${missing.join(", ")}. Rebuild the Electron package after installing @askalf/dario and running electron:prepare.`,
+      );
+    }
+
+    return {
+      command: nodePath,
+      argsPrefix: [cliPath],
+      source: "packaged",
+      description: `${nodePath} ${cliPath}`,
+    };
+  }
+
+  const workspaceCli = resolveWorkspaceDarioCli();
+  if (workspaceCli) {
+    return {
+      command: process.execPath,
+      argsPrefix: [workspaceCli.cliPath],
+      source: workspaceCli.source,
+      description: `${process.execPath} ${workspaceCli.cliPath}`,
+    };
+  }
+
+  const pathBinary = firstExisting(
+    (process.env.PATH ?? "")
+      .split(process.platform === "win32" ? ";" : ":")
+      .filter(Boolean)
+      .map((entry) => join(entry, process.platform === "win32" ? "dario.cmd" : "dario")),
+  );
+
+  return {
+    command: pathBinary ?? "dario",
+    argsPrefix: [],
+    source: "path",
+    description: pathBinary ?? "dario on PATH",
+  };
+}
+
+export function withDarioCommandArgs(resolution: DarioCommandResolution, args: string[]): string[] {
+  return [...resolution.argsPrefix, ...args];
+}

--- a/lib/ai/providers/dario/config.ts
+++ b/lib/ai/providers/dario/config.ts
@@ -1,0 +1,89 @@
+/**
+ * Dario sidecar config management for the Claude Code provider.
+ *
+ * Dario exposes an Anthropic-compatible local proxy. Selene owns the local
+ * bind port and API key so it never has to rely on user-global DARIO_* env.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, resolve } from "node:path";
+
+// Must not collide with packaged Electron's Next internal port (3457).
+export const DARIO_DEFAULT_PORT = 8575;
+export const DARIO_HOST = "127.0.0.1";
+export const DARIO_BASE_URL_PATH = "/v1";
+
+export interface DarioConfigFile {
+  /** Directory for Selene-owned Dario runtime metadata. */
+  dir: string;
+  /** Bearer token clients must send to the local Dario proxy. */
+  apiKey: string;
+  /** Bind port for the Selene-managed Dario proxy. */
+  port: number;
+  /** Bind host. Always loopback unless code is explicitly changed. */
+  host: string;
+}
+
+/**
+ * Return the directory Selene uses for Dario-owned local runtime metadata.
+ * Honors the same LOCAL_DATA_PATH env used by the rest of Selene storage.
+ */
+export function getSeleneDarioDir(): string {
+  const base = process.env.LOCAL_DATA_PATH
+    ? resolve(process.env.LOCAL_DATA_PATH)
+    : resolve(process.cwd(), ".local-data");
+  return join(base, "dario");
+}
+
+function generateApiKey(): string {
+  return `selene-dario-${randomBytes(24).toString("hex")}`;
+}
+
+function loadOrGenerateApiKey(dir: string): string {
+  const keyFile = join(dir, "api-key");
+  if (existsSync(keyFile)) {
+    const existing = readFileSync(keyFile, "utf8").trim();
+    if (existing.length > 0) return existing;
+  }
+
+  const fresh = generateApiKey();
+  writeFileSync(keyFile, fresh, { mode: 0o600 });
+  return fresh;
+}
+
+function resolvePort(): number {
+  const fromEnv = process.env.SELENE_DARIO_PORT;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed < 65536) {
+      return parsed;
+    }
+  }
+  return DARIO_DEFAULT_PORT;
+}
+
+/** Materialize Selene's Dario config and return values needed by callers. */
+export function ensureDarioConfig(): DarioConfigFile {
+  const dir = getSeleneDarioDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  return {
+    dir,
+    apiKey: loadOrGenerateApiKey(dir),
+    port: resolvePort(),
+    host: DARIO_HOST,
+  };
+}
+
+export function getDarioOrigin(port = resolvePort(), host = DARIO_HOST): string {
+  return `http://${host}:${port}`;
+}
+
+export function getDarioBaseUrl(port = resolvePort(), host = DARIO_HOST): string {
+  return `${getDarioOrigin(port, host)}${DARIO_BASE_URL_PATH}`;
+}
+
+export function darioAuthHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}

--- a/lib/ai/providers/dario/environment.ts
+++ b/lib/ai/providers/dario/environment.ts
@@ -1,0 +1,41 @@
+import { buildEnvironmentForTarget } from "@/lib/process-env/policy";
+import { isElectronProduction } from "@/lib/utils/environment";
+import type { DarioConfigFile } from "./config";
+
+const DARIO_ENV_PREFIX = "DARIO_";
+const BLOCKED_DARIO_INHERITED_KEYS = new Set([
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_LOG",
+  "ANTHROPIC_UPSTREAM_API_KEY",
+  "CLAUDECODE",
+]);
+
+/**
+ * Build a Dario child-process environment.
+ *
+ * We preserve PATH/HOME/platform basics through Selene's existing Claude SDK
+ * policy, but remove user-global DARIO_* and Anthropic overrides before
+ * setting Selene-owned host/port/API-key values.
+ */
+export function buildDarioEnvironment(config: DarioConfigFile): NodeJS.ProcessEnv {
+  const { env } = buildEnvironmentForTarget({
+    target: "claude-sdk",
+    isProduction: isElectronProduction(),
+    processEnv: process.env,
+  });
+
+  const next: Record<string, string | undefined> = { ...env };
+  for (const key of Object.keys(next)) {
+    if (key.startsWith(DARIO_ENV_PREFIX) || BLOCKED_DARIO_INHERITED_KEYS.has(key)) {
+      delete next[key];
+    }
+  }
+
+  next.DARIO_API_KEY = config.apiKey;
+  next.DARIO_HOST = config.host;
+  next.DARIO_PORT = String(config.port);
+
+  return next as NodeJS.ProcessEnv;
+}

--- a/lib/ai/providers/dario/index.ts
+++ b/lib/ai/providers/dario/index.ts
@@ -1,0 +1,39 @@
+export {
+  DARIO_BASE_URL_PATH,
+  DARIO_DEFAULT_PORT,
+  DARIO_HOST,
+  darioAuthHeaders,
+  ensureDarioConfig,
+  getDarioBaseUrl,
+  getDarioOrigin,
+  getSeleneDarioDir,
+  type DarioConfigFile,
+} from "./config";
+
+export {
+  ensureDarioSidecarReady,
+  isDarioSidecarReady,
+  stopDarioSidecar,
+  type DarioSidecarReady,
+} from "./sidecar";
+
+export {
+  DarioStatusError,
+  fetchDarioStatus,
+  isDarioStatusUsable,
+  type DarioOAuthStatus,
+  type DarioStatus,
+} from "./status";
+
+export {
+  awaitClaudeLoginCompletion,
+  getClaudeLoginState,
+  killClaudeLogin,
+  logoutClaudeLogin,
+  refreshClaudeLogin,
+  startClaudeLogin,
+  submitClaudeLoginCode,
+  type LoginStart,
+  type LoginState,
+  type LoginStatus,
+} from "./login";

--- a/lib/ai/providers/dario/login.ts
+++ b/lib/ai/providers/dario/login.ts
@@ -82,25 +82,56 @@ export function isSuccessfulClaudeLoginOutput(output: string[] | undefined): boo
   return !output.some((line) => LOGIN_FAILURE_PATTERN.test(line));
 }
 
-function attachOutputCapture(session: LoginSession): void {
-  const onData = (chunk: Buffer): void => {
-    const text = chunk.toString();
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      session.outputLines.push(trimmed);
-      if (isSuccessfulClaudeLoginOutput([trimmed])) {
-        session.status = "success";
+function createLineAccumulator(onLine: (line: string) => void): {
+  capture: (chunk: Buffer | string) => void;
+  flush: () => void;
+} {
+  let buffer = "";
+  return {
+    capture(chunk) {
+      buffer += chunk.toString();
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        onLine(buffer.slice(0, newlineIndex));
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf("\n");
       }
-    }
-    if (!session.url) {
-      const match = text.match(URL_PATTERN);
-      if (match) session.url = match[0];
-    }
+    },
+    flush() {
+      if (!buffer) return;
+      onLine(buffer);
+      buffer = "";
+    },
+  };
+}
+
+function recordLoginOutputLine(session: LoginSession, line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  session.outputLines.push(trimmed);
+  if (!session.url) {
+    const match = trimmed.match(URL_PATTERN);
+    if (match) session.url = match[0];
+  }
+  if (isSuccessfulClaudeLoginOutput([trimmed])) {
+    session.status = "success";
+  }
+}
+
+function attachOutputCapture(session: LoginSession): void {
+  const stdout = createLineAccumulator((line) => recordLoginOutputLine(session, line));
+  const stderr = createLineAccumulator((line) => recordLoginOutputLine(session, line));
+  const flush = (): void => {
+    stdout.flush();
+    stderr.flush();
   };
 
-  session.child.stdout?.on("data", onData);
-  session.child.stderr?.on("data", onData);
+  session.child.stdout?.on("data", stdout.capture);
+  session.child.stderr?.on("data", stderr.capture);
+  session.child.stdout?.on("end", stdout.flush);
+  session.child.stderr?.on("end", stderr.flush);
+  session.child.once("exit", flush);
 }
 
 /**
@@ -214,21 +245,32 @@ async function runDarioCommand(args: string[]): Promise<LoginState> {
   });
 
   const outputLines: string[] = [];
-  const capture = (chunk: Buffer): void => {
-    for (const line of chunk.toString().split("\n")) {
-      const trimmed = line.trim();
-      if (trimmed) outputLines.push(trimmed);
-    }
+  const recordLine = (line: string): void => {
+    const trimmed = line.trim();
+    if (trimmed) outputLines.push(trimmed);
   };
-  child.stdout?.on("data", capture);
-  child.stderr?.on("data", capture);
+  const stdout = createLineAccumulator(recordLine);
+  const stderr = createLineAccumulator(recordLine);
+  const flush = (): void => {
+    stdout.flush();
+    stderr.flush();
+  };
+
+  child.stdout?.on("data", stdout.capture);
+  child.stderr?.on("data", stderr.capture);
+  child.stdout?.on("end", stdout.flush);
+  child.stderr?.on("end", stderr.flush);
 
   const status = await new Promise<LoginStatus>((resolve) => {
     child.once("error", (err) => {
+      flush();
       outputLines.push(`spawn error: ${err.message}`);
       resolve("error");
     });
-    child.once("exit", (code) => resolve(code === 0 ? "success" : "error"));
+    child.once("exit", (code) => {
+      flush();
+      resolve(code === 0 ? "success" : "error");
+    });
   });
 
   if (status === "success") {

--- a/lib/ai/providers/dario/login.ts
+++ b/lib/ai/providers/dario/login.ts
@@ -1,0 +1,258 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { buildDarioEnvironment } from "./environment";
+import { ensureDarioConfig } from "./config";
+import { stopDarioSidecarAndWait } from "./sidecar";
+import { resolveDarioCommand, withDarioCommandArgs } from "./binary";
+
+const URL_PATTERN = /https?:\/\/[^\s"')]+/i;
+const URL_WAIT_MS = 20_000;
+
+export type LoginStatus = "pending" | "success" | "error";
+
+interface LoginSession {
+  child: ChildProcess;
+  url: string | null;
+  outputLines: string[];
+  status: LoginStatus;
+  errorMessage?: string;
+  startedAt: number;
+  codeSubmitted: boolean;
+}
+
+export interface LoginStart {
+  url: string | null;
+  output: string[];
+}
+
+export interface LoginState {
+  active: boolean;
+  status: LoginStatus;
+  url: string | null;
+  output: string[];
+  errorMessage?: string;
+}
+
+type DarioLoginGlobal = typeof globalThis & {
+  __seleneDarioClaudeLogin?: LoginSession | null;
+};
+
+const g = globalThis as DarioLoginGlobal;
+if (!("__seleneDarioClaudeLogin" in g)) g.__seleneDarioClaudeLogin = null;
+
+function getActive(): LoginSession | null {
+  return g.__seleneDarioClaudeLogin ?? null;
+}
+
+function setActive(state: LoginSession | null): void {
+  g.__seleneDarioClaudeLogin = state;
+}
+
+function killActive(): void {
+  const active = getActive();
+  if (!active) return;
+  if (active.child.exitCode === null && !active.child.killed) {
+    active.child.kill("SIGTERM");
+  }
+  setActive(null);
+}
+
+function snapshotState(): LoginState | null {
+  const active = getActive();
+  if (!active) return null;
+  return {
+    active: active.child.exitCode === null && !active.child.killed,
+    status: active.status,
+    url: active.url,
+    output: [...active.outputLines],
+    errorMessage: active.errorMessage,
+  };
+}
+
+const LOGIN_SUCCESS_PATTERNS = [
+  /^found valid credentials\b/i,
+  /^refresh successful!/i,
+  /^login successful!/i,
+];
+const LOGIN_FAILURE_PATTERN = /\b(error|failed|failure|fatal|invalid_grant|rejected)\b/i;
+
+export function isSuccessfulClaudeLoginOutput(output: string[] | undefined): boolean {
+  if (!output || output.length === 0) return false;
+  const hasSuccess = output.some((line) => LOGIN_SUCCESS_PATTERNS.some((pattern) => pattern.test(line.trim())));
+  if (!hasSuccess) return false;
+  return !output.some((line) => LOGIN_FAILURE_PATTERN.test(line));
+}
+
+function attachOutputCapture(session: LoginSession): void {
+  const onData = (chunk: Buffer): void => {
+    const text = chunk.toString();
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      session.outputLines.push(trimmed);
+      if (isSuccessfulClaudeLoginOutput([trimmed])) {
+        session.status = "success";
+      }
+    }
+    if (!session.url) {
+      const match = text.match(URL_PATTERN);
+      if (match) session.url = match[0];
+    }
+  };
+
+  session.child.stdout?.on("data", onData);
+  session.child.stderr?.on("data", onData);
+}
+
+/**
+ * Start Dario's manual login flow.
+ *
+ * Dario prints an OAuth URL and waits for the pasted code on stdin. Selene's
+ * existing UI already posts that code to /exchange, so we keep the child stdin
+ * open and submit it from submitClaudeLoginCode().
+ */
+export async function startClaudeLogin(): Promise<LoginStart> {
+  killActive();
+
+  const config = ensureDarioConfig();
+  const darioCommand = resolveDarioCommand();
+  const child = spawn(darioCommand.command, withDarioCommandArgs(darioCommand, ["login", "--manual", "--no-proxy"]), {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: buildDarioEnvironment(config),
+    detached: false,
+    windowsHide: true,
+  });
+
+  const session: LoginSession = {
+    child,
+    url: null,
+    outputLines: [],
+    status: "pending",
+    startedAt: Date.now(),
+    codeSubmitted: false,
+  };
+  setActive(session);
+  attachOutputCapture(session);
+
+  child.once("error", (err) => {
+    session.status = "error";
+    session.errorMessage = err.message;
+    session.outputLines.push(`spawn error: ${err.message}`);
+  });
+  child.once("exit", (code) => {
+    if (session.status === "pending") {
+      if (code === 0) {
+        session.status = "success";
+      } else {
+        session.status = "error";
+        session.errorMessage = `dario login exited with code ${code}`;
+      }
+    }
+
+    if (session.status === "success") {
+      // Dario's proxy process caches credential reads briefly. If Settings
+      // checked /status before login completed, restart Selene's sidecar so the
+      // next status/read path cannot reuse stale unauthenticated state.
+      void stopDarioSidecarAndWait();
+    }
+  });
+
+  const deadline = Date.now() + URL_WAIT_MS;
+  while (Date.now() < deadline && !session.url && session.status === "pending") {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  if (session.status === "success") {
+    await stopDarioSidecarAndWait();
+  }
+
+  return { url: session.url, output: [...session.outputLines] };
+}
+
+export function submitClaudeLoginCode(code: string): void {
+  const active = getActive();
+  if (!active || active.child.exitCode !== null || active.child.killed) {
+    throw new Error("No active Dario OAuth login. Click 'Login with Claude' to start a new flow.");
+  }
+
+  const trimmed = code.trim();
+  if (!trimmed) {
+    throw new Error("Paste the authorization code from the Claude login page.");
+  }
+
+  if (!active.codeSubmitted) {
+    active.child.stdin?.write(`${trimmed}\n`);
+    active.codeSubmitted = true;
+  }
+}
+
+export function getClaudeLoginState(): LoginState | null {
+  return snapshotState();
+}
+
+export async function awaitClaudeLoginCompletion(timeoutMs = 120_000): Promise<LoginState | null> {
+  const active = getActive();
+  if (!active) return null;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && active.status === "pending") {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return snapshotState();
+}
+
+export function killClaudeLogin(): void {
+  killActive();
+}
+
+async function runDarioCommand(args: string[]): Promise<LoginState> {
+  const config = ensureDarioConfig();
+  const darioCommand = resolveDarioCommand();
+  const child = spawn(darioCommand.command, withDarioCommandArgs(darioCommand, args), {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: buildDarioEnvironment(config),
+    detached: false,
+    windowsHide: true,
+  });
+
+  const outputLines: string[] = [];
+  const capture = (chunk: Buffer): void => {
+    for (const line of chunk.toString().split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed) outputLines.push(trimmed);
+    }
+  };
+  child.stdout?.on("data", capture);
+  child.stderr?.on("data", capture);
+
+  const status = await new Promise<LoginStatus>((resolve) => {
+    child.once("error", (err) => {
+      outputLines.push(`spawn error: ${err.message}`);
+      resolve("error");
+    });
+    child.once("exit", (code) => resolve(code === 0 ? "success" : "error"));
+  });
+
+  if (status === "success") {
+    await stopDarioSidecarAndWait();
+  }
+
+  return {
+    active: false,
+    status,
+    url: null,
+    output: outputLines,
+    errorMessage: status === "error" ? outputLines[outputLines.length - 1] : undefined,
+  };
+}
+
+export async function refreshClaudeLogin(): Promise<LoginState> {
+  return runDarioCommand(["refresh"]);
+}
+
+export async function logoutClaudeLogin(): Promise<LoginState> {
+  const result = await runDarioCommand(["logout"]);
+  // Dario keeps an in-memory credential cache in the proxy process; restart it
+  // after logout so subsequent status checks cannot reuse stale credentials.
+  setActive(null);
+  await stopDarioSidecarAndWait();
+  return result;
+}

--- a/lib/ai/providers/dario/sidecar.ts
+++ b/lib/ai/providers/dario/sidecar.ts
@@ -124,7 +124,7 @@ async function validateDarioApiKey(port: number, apiKey: string): Promise<void> 
   }
 }
 
-async function startDarioSidecar(): Promise<DarioSidecarReady> {
+async function startDarioSidecar(allowStartupRetry = true): Promise<DarioSidecarReady> {
   const config = ensureDarioConfig();
   const { apiKey, port, host } = config;
   const env = buildDarioEnvironment(config);
@@ -181,9 +181,12 @@ async function startDarioSidecar(): Promise<DarioSidecarReady> {
     // TCP stack can keep it in TIME_WAIT for a brief window. Retry once
     // after settling to avoid a permanent error from a transient bind fail.
     if (process.env.SELENE_DARIO_ALLOW_EXTERNAL !== "1") {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      const retry = await startDarioSidecar();
-      return retry;
+      if (allowStartupRetry) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return startDarioSidecar(false);
+      }
+
+      throw new Error("Dario sidecar exited during startup after retry.");
     }
   }
 

--- a/lib/ai/providers/dario/sidecar.ts
+++ b/lib/ai/providers/dario/sidecar.ts
@@ -1,0 +1,276 @@
+/**
+ * Dario sidecar lifecycle for the Claude Code provider.
+ *
+ * Dario is process-ready when its HTTP server responds on /health. Auth health
+ * is intentionally separate and is read from /status.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { buildDarioEnvironment } from "./environment";
+import {
+  darioAuthHeaders,
+  ensureDarioConfig,
+  getDarioBaseUrl,
+  getDarioOrigin,
+} from "./config";
+import { resolveDarioCommand, withDarioCommandArgs } from "./binary";
+
+const READY_TIMEOUT_MS = 20_000;
+const READY_POLL_INTERVAL_MS = 200;
+const STOP_TIMEOUT_MS = 3_000;
+
+interface SidecarState {
+  child: ChildProcess;
+  port: number;
+  apiKey: string;
+  ready: boolean;
+  startedAt: number;
+}
+
+export interface DarioSidecarReady {
+  port: number;
+  apiKey: string;
+  baseUrl: string;
+}
+
+type DarioGlobal = typeof globalThis & {
+  __seleneDarioSidecar?: SidecarState | null;
+  __seleneDarioSidecarStart?: Promise<DarioSidecarReady> | null;
+  __seleneDarioExitHooked?: boolean;
+};
+
+const g = globalThis as DarioGlobal;
+if (!("__seleneDarioSidecar" in g)) g.__seleneDarioSidecar = null;
+if (!("__seleneDarioSidecarStart" in g)) g.__seleneDarioSidecarStart = null;
+
+function getActive(): SidecarState | null {
+  return g.__seleneDarioSidecar ?? null;
+}
+
+function setActive(state: SidecarState | null): void {
+  g.__seleneDarioSidecar = state;
+}
+
+function isAlive(child: ChildProcess): boolean {
+  return child.exitCode === null && !child.killed;
+}
+
+function pipeChildOutput(child: ChildProcess): void {
+  const forward = (stream: NodeJS.ReadableStream | null, level: "log" | "error"): void => {
+    if (!stream) return;
+    let buffer = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk: string) => {
+      buffer += chunk;
+      let nlIndex = buffer.indexOf("\n");
+      while (nlIndex !== -1) {
+        const line = buffer.slice(0, nlIndex).trimEnd();
+        buffer = buffer.slice(nlIndex + 1);
+        if (line) console[level](`[dario] ${line}`);
+        nlIndex = buffer.indexOf("\n");
+      }
+    });
+    stream.on("end", () => {
+      if (buffer.trim()) console[level](`[dario] ${buffer.trim()}`);
+    });
+  };
+  forward(child.stdout, "log");
+  forward(child.stderr, "error");
+}
+
+function attachLifecycle(child: ChildProcess): void {
+  child.once("exit", (code, signal) => {
+    const active = getActive();
+    if (active && active.child === child) setActive(null);
+    if (code !== 0 && code !== null) {
+      console.warn(`[dario] sidecar exited code=${code} signal=${signal ?? "none"}`);
+    }
+  });
+  child.once("error", (err) => {
+    console.error(`[dario] sidecar spawn error: ${err.message}`);
+  });
+}
+
+async function pollDarioListening(port: number, deadline: number): Promise<boolean> {
+  const url = `${getDarioOrigin(port)}/health`;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      // Dario returns 503 on /health when OAuth is missing/broken. That still
+      // proves the process is listening; auth is validated separately.
+      if (res.status === 200 || res.status === 503) return true;
+    } catch {
+      // sidecar not yet listening — keep polling
+    }
+    await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+async function validateDarioApiKey(port: number, apiKey: string): Promise<void> {
+  const res = await fetch(`${getDarioOrigin(port)}/status`, {
+    headers: darioAuthHeaders(apiKey),
+    signal: AbortSignal.timeout(1_000),
+  });
+
+  if (res.status === 401) {
+    throw new Error(
+      "Dario rejected Selene's API key. Another Dario instance may already be using this port.",
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`Dario /status returned HTTP ${res.status}`);
+  }
+}
+
+async function startDarioSidecar(): Promise<DarioSidecarReady> {
+  const config = ensureDarioConfig();
+  const { apiKey, port, host } = config;
+  const env = buildDarioEnvironment(config);
+  const darioCommand = resolveDarioCommand();
+
+  const child = spawn(
+    darioCommand.command,
+    withDarioCommandArgs(darioCommand, ["proxy", `--port=${port}`, `--host=${host}`]),
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      detached: false,
+      windowsHide: true,
+    },
+  );
+
+  pipeChildOutput(child);
+  attachLifecycle(child);
+
+  let spawnErrorMessage: string | null = null;
+  child.once("error", (err) => {
+    spawnErrorMessage = err.message;
+  });
+
+  const state: SidecarState = {
+    child,
+    port,
+    apiKey,
+    ready: false,
+    startedAt: Date.now(),
+  };
+  setActive(state);
+
+  const ready = await pollDarioListening(port, Date.now() + READY_TIMEOUT_MS);
+  if (!ready) {
+    stopDarioSidecar();
+    const detail = spawnErrorMessage ? ` Spawn error: ${spawnErrorMessage}` : "";
+    throw new Error(
+      `Dario sidecar did not become ready within ${READY_TIMEOUT_MS}ms. `
+      + `Tried: ${darioCommand.description}.${detail}`,
+    );
+  }
+
+  await validateDarioApiKey(port, apiKey);
+  // Dario exits quickly with code 0 when it detects an existing proxy on the
+  // requested port. Give that path a chance to settle before accepting the
+  // child as Selene-managed.
+  await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
+
+  if (!isAlive(child)) {
+    setActive(null);
+
+    // A prior stopDarioSidecarAndWait may have freed the port, but the OS
+    // TCP stack can keep it in TIME_WAIT for a brief window. Retry once
+    // after settling to avoid a permanent error from a transient bind fail.
+    if (process.env.SELENE_DARIO_ALLOW_EXTERNAL !== "1") {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const retry = await startDarioSidecar();
+      return retry;
+    }
+  }
+
+  state.ready = true;
+  return {
+    port,
+    apiKey,
+    baseUrl: getDarioBaseUrl(port, host),
+  };
+}
+
+/** Ensure the Selene-managed Dario sidecar is running and accepting requests. */
+export async function ensureDarioSidecarReady(): Promise<DarioSidecarReady> {
+  const existing = getActive();
+  if (existing && isAlive(existing.child) && existing.ready) {
+    return {
+      port: existing.port,
+      apiKey: existing.apiKey,
+      baseUrl: getDarioBaseUrl(existing.port),
+    };
+  }
+
+  if (g.__seleneDarioSidecarStart) {
+    return g.__seleneDarioSidecarStart;
+  }
+
+  if (existing && !isAlive(existing.child)) setActive(null);
+
+  g.__seleneDarioSidecarStart = startDarioSidecar().finally(() => {
+    g.__seleneDarioSidecarStart = null;
+  });
+  return g.__seleneDarioSidecarStart;
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (!isAlive(child)) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs);
+    const done = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    child.once("exit", done);
+    child.once("error", done);
+  });
+}
+
+async function waitForDarioPortClosed(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${getDarioOrigin(port)}/health`, { signal: AbortSignal.timeout(250) });
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
+  }
+}
+
+
+export function stopDarioSidecar(): void {
+  const active = getActive();
+  if (!active) return;
+  if (isAlive(active.child)) active.child.kill("SIGTERM");
+  setActive(null);
+}
+
+export async function stopDarioSidecarAndWait(timeoutMs = STOP_TIMEOUT_MS): Promise<void> {
+  const active = getActive();
+  if (!active) return;
+
+  const child = active.child;
+  const exit = waitForChildExit(child, timeoutMs);
+  if (isAlive(child)) child.kill("SIGTERM");
+  setActive(null);
+  await exit;
+  await waitForDarioPortClosed(active.port, Math.min(timeoutMs, 1_000));
+}
+
+export function isDarioSidecarReady(): boolean {
+  const active = getActive();
+  return !!active && isAlive(active.child) && active.ready;
+}
+
+if (!g.__seleneDarioExitHooked) {
+  g.__seleneDarioExitHooked = true;
+  for (const signal of ["SIGINT", "SIGTERM", "exit"] as const) {
+    process.on(signal, () => stopDarioSidecar());
+  }
+}

--- a/lib/ai/providers/dario/status.ts
+++ b/lib/ai/providers/dario/status.ts
@@ -1,0 +1,83 @@
+import { darioAuthHeaders, ensureDarioConfig, getDarioOrigin } from "./config";
+import { ensureDarioSidecarReady } from "./sidecar";
+
+export type DarioOAuthStatus = "healthy" | "expiring" | "expired" | "broken" | "none";
+
+export interface DarioStatus {
+  authenticated: boolean;
+  status: DarioOAuthStatus;
+  expiresAt?: number;
+  expiresIn?: string;
+  canRefresh?: boolean;
+  refreshFailures?: number;
+  lastRefreshError?: string;
+}
+
+export class DarioStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "DarioStatusError";
+  }
+}
+
+export function isDarioStatus(value: unknown): value is DarioStatus {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Partial<DarioStatus>;
+  return typeof obj.authenticated === "boolean"
+    && typeof obj.status === "string"
+    && ["healthy", "expiring", "expired", "broken", "none"].includes(obj.status);
+}
+
+async function fetchDirectDarioStatus(): Promise<DarioStatus> {
+  const dario = await import("@askalf/dario");
+  const status = await dario.getStatus();
+  if (!isDarioStatus(status)) {
+    throw new DarioStatusError("Dario getStatus() returned an unexpected response shape");
+  }
+  return status;
+}
+
+async function fetchProxyDarioStatus(): Promise<DarioStatus> {
+  await ensureDarioSidecarReady();
+
+  const { apiKey, port, host } = ensureDarioConfig();
+  const res = await fetch(`${getDarioOrigin(port, host)}/status`, {
+    headers: darioAuthHeaders(apiKey),
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  if (res.status === 401) {
+    throw new DarioStatusError(
+      "Dario rejected Selene's API key. Another Dario instance may already be using the configured port.",
+      401,
+    );
+  }
+
+  if (!res.ok) {
+    throw new DarioStatusError(`Dario status endpoint returned HTTP ${res.status}`, res.status);
+  }
+
+  const json = await res.json();
+  if (!isDarioStatus(json)) {
+    throw new DarioStatusError("Dario status endpoint returned an unexpected response shape");
+  }
+
+  return json;
+}
+
+export async function fetchDarioStatus(options: { ensureReady?: boolean } = {}): Promise<DarioStatus> {
+  const shouldEnsureReady = options.ensureReady ?? false;
+  return shouldEnsureReady ? fetchProxyDarioStatus() : fetchDirectDarioStatus();
+}
+
+/**
+ * Dario can refresh expired credentials on proxy startup/request when a refresh
+ * token exists, so expired+canRefresh should remain usable in Selene UI state.
+ */
+export function isDarioStatusUsable(status: DarioStatus): boolean {
+  if (status.authenticated) return true;
+  return status.status === "expired" && status.canRefresh === true;
+}

--- a/lib/auth/claudecode-auth.ts
+++ b/lib/auth/claudecode-auth.ts
@@ -173,9 +173,12 @@ export async function verifyClaudeCodeAuthenticatedAfterDarioLogin(output: strin
 
 /** Clear Dario's stored credentials and reset Selene's cached snapshot. */
 export async function clearClaudeCodeAuth(): Promise<void> {
-  await logoutClaudeLogin().catch((err) => {
+  try {
+    await logoutClaudeLogin();
+  } catch (err) {
     console.error("[claudecode-auth] failed to clear dario credentials:", err);
-  });
+    throw err;
+  }
 
   const settings = loadSettings();
   settings.claudecodeAuth = {

--- a/lib/auth/claudecode-auth.ts
+++ b/lib/auth/claudecode-auth.ts
@@ -1,21 +1,23 @@
 /**
- * Claude Code auth state — backed by the CLIProxyAPI sidecar's credential
- * dir.
+ * Claude Code auth state — backed by Dario's Claude subscription OAuth state.
  *
- * Selene no longer keeps its own OAuth token storage. The sidecar runs the
- * OAuth flow and persists `claude-<email>.json` files; we read those to
- * derive the user-facing auth status and persist a small cached snapshot in
- * `settings.json` so the UI doesn't flicker between page loads.
+ * Selene no longer keeps its own OAuth token storage. Dario owns Claude Code
+ * OAuth discovery/refresh and exposes a local /status endpoint; Selene mirrors
+ * that state into settings.json so the UI doesn't flicker between page loads.
  */
 
 import { loadSettings, saveSettings } from "@/lib/settings/settings-manager";
 import {
-  deleteAllClaudeCredentials,
-  listClaudeCredentials,
-} from "@/lib/ai/providers/cliproxy/credentials";
-import { getClaudeLoginState } from "@/lib/ai/providers/cliproxy/login";
+  fetchDarioStatus,
+  isDarioStatusUsable,
+  type DarioStatus,
+} from "@/lib/ai/providers/dario/status";
+import {
+  getClaudeLoginState,
+  logoutClaudeLogin,
+} from "@/lib/ai/providers/dario/login";
 
-const TOKEN_SOURCE = "cliproxyapi-oauth";
+const TOKEN_SOURCE = "dario-oauth";
 
 export interface ClaudeCodeAuthStatus {
   authenticated: boolean;
@@ -26,6 +28,8 @@ export interface ClaudeCodeAuthStatus {
   authUrl?: string;
   output?: string[];
   error?: string;
+  expiresAt?: number;
+  expiresIn?: string;
 }
 
 interface ClaudeCodeAuthState {
@@ -46,7 +50,7 @@ function buildAuthStateFromStatus(status: ClaudeCodeAuthStatus): ClaudeCodeAuthS
   return {
     isAuthenticated: status.authenticated,
     email: status.email,
-    expiresAt: undefined,
+    expiresAt: status.expiresAt,
     lastRefresh: Date.now(),
     tokenSource: status.tokenSource,
     apiKeySource: status.apiKeySource,
@@ -94,47 +98,53 @@ export function invalidateClaudeCodeAuthCache(): void {
   cachedAuthState = null;
 }
 
-/**
- * Re-read upstream credential files and refresh the persisted snapshot.
- */
+function darioStatusError(status: DarioStatus): string | undefined {
+  if (isDarioStatusUsable(status)) return undefined;
+  if (status.status === "broken") {
+    return status.lastRefreshError
+      ? `Dario OAuth refresh is broken: ${status.lastRefreshError}`
+      : "Dario OAuth refresh is broken. Retry Claude Code authentication through Dario.";
+  }
+  if (status.status === "expired" && status.canRefresh === false) {
+    return "Dario OAuth credentials are expired and cannot be refreshed. Retry Claude Code authentication through Dario.";
+  }
+  return undefined;
+}
+
+function mapDarioStatus(status: DarioStatus, output?: string[]): ClaudeCodeAuthStatus {
+  const loginState = getClaudeLoginState();
+  return {
+    authenticated: isDarioStatusUsable(status),
+    tokenSource: TOKEN_SOURCE,
+    apiKeySource: "dario-local-proxy",
+    authUrl: loginState?.url ?? undefined,
+    output: output ?? loginState?.output,
+    error: darioStatusError(status) ?? loginState?.errorMessage,
+    expiresAt: status.expiresAt,
+    expiresIn: status.expiresIn,
+  };
+}
+
+/** Re-read Dario status and refresh the persisted auth snapshot. */
 export async function getClaudeCodeAuthStatus(): Promise<ClaudeCodeAuthStatus> {
-  let creds;
   try {
-    creds = await listClaudeCredentials();
+    const dario = await fetchDarioStatus();
+    const status = mapDarioStatus(dario);
+    persistAuthState(status);
+    return status;
   } catch (err) {
+    const loginState = getClaudeLoginState();
     const status: ClaudeCodeAuthStatus = {
       authenticated: false,
       tokenSource: TOKEN_SOURCE,
+      apiKeySource: "dario-local-proxy",
+      authUrl: loginState?.url ?? undefined,
+      output: loginState?.output,
       error: err instanceof Error ? err.message : String(err),
     };
     persistAuthState(status);
     return status;
   }
-
-  const loginState = getClaudeLoginState();
-
-  if (creds.length === 0) {
-    const status: ClaudeCodeAuthStatus = {
-      authenticated: false,
-      tokenSource: TOKEN_SOURCE,
-      authUrl: loginState?.url ?? undefined,
-      output: loginState?.output,
-      error: loginState?.errorMessage,
-    };
-    persistAuthState(status);
-    return status;
-  }
-
-  const primary = creds[0];
-  const status: ClaudeCodeAuthStatus = {
-    authenticated: true,
-    email: primary.email,
-    account: primary.email,
-    tokenSource: TOKEN_SOURCE,
-    output: loginState?.output,
-  };
-  persistAuthState(status);
-  return status;
 }
 
 export async function isClaudeCodeAuthenticated(): Promise<boolean> {
@@ -142,18 +152,37 @@ export async function isClaudeCodeAuthenticated(): Promise<boolean> {
   return status.authenticated;
 }
 
-/**
- * Delete the sidecar's stored credentials and reset selene's cached snapshot.
- */
+export async function verifyClaudeCodeAuthenticatedAfterDarioLogin(output: string[] = []): Promise<ClaudeCodeAuthStatus> {
+  try {
+    const dario = await fetchDarioStatus({ ensureReady: true });
+    const status = mapDarioStatus(dario, output);
+    persistAuthState(status);
+    return status;
+  } catch (err) {
+    const status: ClaudeCodeAuthStatus = {
+      authenticated: false,
+      tokenSource: TOKEN_SOURCE,
+      apiKeySource: "dario-local-proxy",
+      output,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    persistAuthState(status);
+    return status;
+  }
+}
+
+/** Clear Dario's stored credentials and reset Selene's cached snapshot. */
 export async function clearClaudeCodeAuth(): Promise<void> {
-  await deleteAllClaudeCredentials().catch((err) => {
-    console.error("[claudecode-auth] failed to delete credentials:", err);
+  await logoutClaudeLogin().catch((err) => {
+    console.error("[claudecode-auth] failed to clear dario credentials:", err);
   });
 
   const settings = loadSettings();
   settings.claudecodeAuth = {
     isAuthenticated: false,
     lastRefresh: Date.now(),
+    tokenSource: TOKEN_SOURCE,
+    apiKeySource: "dario-local-proxy",
   };
   delete settings.claudecodeToken;
   delete settings.pendingClaudeCodeOAuth;

--- a/lib/auth/claudecode-models.ts
+++ b/lib/auth/claudecode-models.ts
@@ -4,6 +4,8 @@ export const CLAUDECODE_MODEL_IDS = [
   "claude-sonnet-4-6",
   "claude-sonnet-4-5-20250929",
   "claude-haiku-4-5-20251001",
+  "claude-fable-5",
+  "claude-opus-4-8",
 ] as const;
 
 type ClaudeCodeModelId = (typeof CLAUDECODE_MODEL_IDS)[number];
@@ -14,6 +16,8 @@ const MODEL_LABELS: Record<string, string> = {
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-sonnet-4-5-20250929": "Claude Sonnet 4.5",
   "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+  "claude-fable-5": "Claude Fable 5",
+  "claude-opus-4-8": "Claude Opus 4.8",
 };
 
 function getClaudeCodeModelDisplayName(modelId: string): string {

--- a/lib/channels/manager.ts
+++ b/lib/channels/manager.ts
@@ -14,10 +14,16 @@ import { ChannelConnector, ChannelSendPayload, ChannelSendResult, ChannelStatus,
 // Lazy import to break the inbound ↔ manager circular dependency.
 // inbound.ts needs getChannelManager() at runtime; manager.ts needs
 // handleInboundMessage at runtime. Both are only called after the module
-// graph is fully resolved, so a deferred require is safe here.
+// graph is fully resolved, so a deferred import is safe here.
+// NOTE: must be a dynamic import(), not require() — in the production
+// Turbopack bundle inbound.ts is an async module (its import graph contains
+// top-level await), so a synchronous require returns a pending Promise
+// namespace and `.handleInboundMessage` would be undefined.
 function getHandleInboundMessage(): (msg: ChannelInboundMessage) => Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return (require("./inbound") as { handleInboundMessage: (msg: ChannelInboundMessage) => Promise<void> }).handleInboundMessage;
+  return async (msg: ChannelInboundMessage) => {
+    const { handleInboundMessage } = await import("./inbound");
+    return handleInboundMessage(msg);
+  };
 }
 
 class ChannelManager {

--- a/lib/config/model-catalog.ts
+++ b/lib/config/model-catalog.ts
@@ -39,8 +39,16 @@ const MODEL_METADATA: Record<
   string,
   Partial<Pick<ModelItem, "tier"> & { capabilities: Partial<ModelCapabilities> }>
 > = {
-  // Anthropic direct
-  // --- 4.7 / 4.6 / 4.5 Series ---
+  // Anthropic direct / Claude Code
+  // --- 5 / 4.8 / 4.7 / 4.6 / 4.5 Series ---
+  "claude-fable-5": {
+    tier: "flagship",
+    capabilities: { vision: true, thinking: true, contextWindow: "1M", speed: "standard" },
+  },
+  "claude-opus-4-8": {
+    tier: "flagship",
+    capabilities: { vision: true, thinking: true, contextWindow: "1M", speed: "standard" },
+  },
   "claude-opus-4-7": {
     tier: "flagship",
     capabilities: { vision: true, thinking: true, contextWindow: "1M", speed: "standard" },

--- a/lib/context-window/provider-limits.ts
+++ b/lib/context-window/provider-limits.ts
@@ -145,7 +145,14 @@ const MODEL_CONTEXT_CONFIGS: Record<string, Partial<ContextWindowConfig>> = {
     supportsStreaming: true,
   },
 
-  // Claude Code — Opus 4.7 / 4.6 have 1M context via Agent SDK
+  // Claude Code — Opus 4.8 / 4.7 / 4.6 and Fable 5 have 1M context via Dario.
+  "claude-opus-4-8": {
+    maxTokens: 1000000,
+    supportsStreaming: true,
+    warningThreshold: 0.80,
+    criticalThreshold: 0.92,
+    hardLimit: 0.97,
+  },
   "claude-opus-4-7": {
     maxTokens: 1000000,
     supportsStreaming: true,
@@ -154,6 +161,13 @@ const MODEL_CONTEXT_CONFIGS: Record<string, Partial<ContextWindowConfig>> = {
     hardLimit: 0.97,
   },
   "claude-opus-4-6": {
+    maxTokens: 1000000,
+    supportsStreaming: true,
+    warningThreshold: 0.80,
+    criticalThreshold: 0.92,
+    hardLimit: 0.97,
+  },
+  "claude-fable-5": {
     maxTokens: 1000000,
     supportsStreaming: true,
     warningThreshold: 0.80,

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,6 +128,7 @@
       "kimiWaitingAuth": "Waiting for authorization...",
       "kimiOpenLoginPage": "Open Kimi Login Page",
       "claudecodeLoginHint": "Make sure you are logged into Claude Code on your device before signing in here.",
+      "noAuthUrl": "Dario did not return an authentication URL. Retry Claude Code authentication from Settings if this persists.",
       "apiKeySaved": "API Key saved!",
       "saving": "Saving...",
       "saveApiKey": "Save API Key",
@@ -2384,7 +2385,8 @@
         "done": "Done",
         "diagnosticDetails": "Diagnostic details",
         "manualLoginBefore": "Could not open the authentication page automatically. Run ",
-        "manualLoginAfter": " in your terminal, then paste the authorization code below."
+        "manualLoginAfter": " in your terminal, then paste the authorization code below.",
+        "noAuthUrl": "Dario did not return an authentication URL. Review the diagnostic output below, then retry Claude Code authentication."
       },
       "fields": {
         "anthropic": {

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -128,6 +128,7 @@
       "kimiWaitingAuth": "Yetkilendirme bekleniyor...",
       "kimiOpenLoginPage": "Kimi Giriş Sayfasını Aç",
       "claudecodeLoginHint": "Burada giriş yapmadan önce cihazınızda Claude Code'a giriş yaptığınızdan emin olun.",
+      "noAuthUrl": "Dario kimlik doğrulama URL'si döndürmedi. Sorun devam ederse Ayarlar'dan Claude Code kimlik doğrulamasını yeniden deneyin.",
       "apiKeySaved": "API Anahtarı kaydedildi!",
       "saving": "Kaydediliyor...",
       "saveApiKey": "API Anahtarını Kaydet",
@@ -2414,7 +2415,8 @@
         "antigravityWarning": "Hesap banlanma riski vardır, kendi sorumluluğunuzda kullanın",
         "diagnosticDetails": "Tanılama ayrıntıları",
         "manualLoginBefore": "Kimlik doğrulama sayfası otomatik olarak açılamadı. Terminalinizde ",
-        "manualLoginAfter": " komutunu çalıştırın, ardından yetkilendirme kodunu aşağıya yapıştırın."
+        "manualLoginAfter": " komutunu çalıştırın, ardından yetkilendirme kodunu aşağıya yapıştırın.",
+        "noAuthUrl": "Dario kimlik doğrulama URL'si döndürmedi. Aşağıdaki tanılama çıktısını inceleyin ve Claude Code kimlik doğrulamasını yeniden deneyin."
       },
       "fields": {
         "anthropic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/provider": "^3.0.8",
         "@ai-sdk/provider-utils": "^4.0.23",
         "@ai-sdk/react": "^3.0.170",
+        "@askalf/dario": "4.8.55",
         "@assistant-ui/react": "^0.12.25",
         "@assistant-ui/react-ai-sdk": "^1.3.19",
         "@assistant-ui/react-markdown": "^0.12.9",
@@ -303,6 +304,18 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/@askalf/dario": {
+      "version": "4.8.55",
+      "resolved": "https://registry.npmjs.org/@askalf/dario/-/dario-4.8.55.tgz",
+      "integrity": "sha512-1FiFnmC06+ySegmMCX0oQGJOFNFWZxjF3lVLqGw2dxBDNAGZJu2MDsUfA01ulgkAsWBPUo20FzIlk0HKN9dq4A==",
+      "license": "MIT",
+      "bin": {
+        "dario": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@assistant-ui/core": {
       "version": "0.1.14",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/provider-utils": "^4.0.23",
     "@ai-sdk/react": "^3.0.170",
+    "@askalf/dario": "4.8.55",
     "@assistant-ui/react": "^0.12.25",
     "@assistant-ui/react-ai-sdk": "^1.3.19",
     "@assistant-ui/react-markdown": "^0.12.9",

--- a/scripts/electron-prepare.js
+++ b/scripts/electron-prepare.js
@@ -314,6 +314,7 @@ copyNodeDependencies([
 copyNodeDependencies([
     { name: 'gpt-tokenizer', src: 'gpt-tokenizer', dest: 'gpt-tokenizer' },
     { name: '@huggingface/hub', src: '@huggingface/hub', dest: '@huggingface/hub' },
+    { name: '@askalf/dario', src: '@askalf/dario', dest: '@askalf/dario' },
 ]);
 
 // 7. Copy Puppeteer and bundled Chromium for local web scraping

--- a/scripts/verify-package.js
+++ b/scripts/verify-package.js
@@ -104,6 +104,7 @@ const requiredPaths = [
   (platform === 'win32' || platform === 'win')
     ? 'standalone/node_modules/@vscode/ripgrep/bin/rg.exe'
     : 'standalone/node_modules/@vscode/ripgrep/bin/rg',
+  'standalone/node_modules/@askalf/dario/dist/cli.js',
 ];
 
 // RTK bundle is optional at runtime (experimental), but warn if absent in package.

--- a/tests/app/api/auth/claudecode/authorize-route.test.ts
+++ b/tests/app/api/auth/claudecode/authorize-route.test.ts
@@ -107,6 +107,29 @@ describe("GET /api/auth/claudecode/authorize", () => {
     });
   });
 
+  it("falls back to a fresh status read when Dario returns no URL and no success output", async () => {
+    getClaudeCodeAuthStatus
+      .mockResolvedValueOnce({ authenticated: false })
+      .mockResolvedValueOnce({ authenticated: false });
+    startClaudeLogin.mockResolvedValueOnce({
+      url: null,
+      output: ["some non-success message"],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(getClaudeCodeAuthStatus).toHaveBeenCalledTimes(2);
+    expect(verifyClaudeCodeAuthenticatedAfterDarioLogin).not.toHaveBeenCalled();
+    expect(response.status).toBe(502);
+    expect(body).toMatchObject({
+      success: false,
+      authenticated: false,
+      output: ["some non-success message"],
+      error: "Dario did not return an authentication URL or verified credentials.",
+    });
+  });
+
   it("returns the OAuth URL when Dario starts a fresh manual login", async () => {
     startClaudeLogin.mockResolvedValueOnce({
       url: "https://claude.ai/oauth/start",

--- a/tests/app/api/auth/claudecode/authorize-route.test.ts
+++ b/tests/app/api/auth/claudecode/authorize-route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getClaudeCodeAuthStatus, startClaudeLogin, verifyClaudeCodeAuthenticatedAfterDarioLogin } = vi.hoisted(() => ({
+  getClaudeCodeAuthStatus: vi.fn(),
+  startClaudeLogin: vi.fn(),
+  verifyClaudeCodeAuthenticatedAfterDarioLogin: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/claudecode-auth", () => ({
+  getClaudeCodeAuthStatus,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
+}));
+
+vi.mock("@/lib/ai/providers/dario/login", () => ({
+  isSuccessfulClaudeLoginOutput: (output: string[] | undefined) => {
+    if (!output || output.length === 0) return false;
+    const hasSuccess = output.some((line) => [
+      /^found valid credentials\b/i,
+      /^refresh successful!/i,
+      /^login successful!/i,
+    ].some((pattern) => pattern.test(line.trim())));
+    return hasSuccess && !output.some((line) => /\b(error|failed|failure|fatal|invalid_grant|rejected)\b/i.test(line));
+  },
+  startClaudeLogin,
+}));
+
+import { GET } from "@/app/api/auth/claudecode/authorize/route";
+
+describe("GET /api/auth/claudecode/authorize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClaudeCodeAuthStatus.mockResolvedValue({ authenticated: false });
+    verifyClaudeCodeAuthenticatedAfterDarioLogin.mockResolvedValue({ authenticated: true });
+    startClaudeLogin.mockResolvedValue({ url: "https://claude.ai/oauth", output: [] });
+  });
+
+  it("short-circuits when Dario already has usable Claude credentials", async () => {
+    getClaudeCodeAuthStatus.mockResolvedValueOnce({ authenticated: true });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body).toMatchObject({ success: true, authenticated: true });
+    expect(startClaudeLogin).not.toHaveBeenCalled();
+  });
+
+  it("verifies a no-url Dario refresh before completing authentication", async () => {
+    getClaudeCodeAuthStatus.mockResolvedValueOnce({ authenticated: false });
+    startClaudeLogin.mockResolvedValueOnce({
+      url: null,
+      output: ["Existing credentials expired — attempting token refresh...", "Refresh successful!"],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(startClaudeLogin).toHaveBeenCalledTimes(1);
+    expect(getClaudeCodeAuthStatus).toHaveBeenCalledTimes(1);
+    expect(verifyClaudeCodeAuthenticatedAfterDarioLogin).toHaveBeenCalledWith([
+      "Existing credentials expired — attempting token refresh...",
+      "Refresh successful!",
+    ]);
+    expect(body).toMatchObject({
+      success: true,
+      authenticated: true,
+      message: "Claude Code credentials are available through Dario",
+    });
+    expect(body.output).toContain("Refresh successful!");
+  });
+
+  it("verifies Dario's no-url valid-credentials output before completing authentication", async () => {
+    getClaudeCodeAuthStatus.mockResolvedValueOnce({ authenticated: false });
+    startClaudeLogin.mockResolvedValueOnce({
+      url: null,
+      output: ["Found valid credentials. (--no-proxy / --manual: not starting proxy.)"],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(getClaudeCodeAuthStatus).toHaveBeenCalledTimes(1);
+    expect(verifyClaudeCodeAuthenticatedAfterDarioLogin).toHaveBeenCalledWith([
+      "Found valid credentials. (--no-proxy / --manual: not starting proxy.)",
+    ]);
+    expect(body).toMatchObject({ success: true, authenticated: true });
+  });
+
+  it("does not complete authentication when Dario success output cannot be verified", async () => {
+    getClaudeCodeAuthStatus.mockResolvedValueOnce({ authenticated: false });
+    verifyClaudeCodeAuthenticatedAfterDarioLogin.mockResolvedValueOnce({
+      authenticated: false,
+      error: "Dario status endpoint returned HTTP 503",
+    });
+    startClaudeLogin.mockResolvedValueOnce({
+      url: null,
+      output: ["Found valid credentials. (--no-proxy / --manual: not starting proxy.)"],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toMatchObject({
+      success: false,
+      authenticated: false,
+      error: "Dario status endpoint returned HTTP 503",
+    });
+  });
+
+  it("returns the OAuth URL when Dario starts a fresh manual login", async () => {
+    startClaudeLogin.mockResolvedValueOnce({
+      url: "https://claude.ai/oauth/start",
+      output: ["Open this URL"],
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      success: true,
+      authenticated: false,
+      url: "https://claude.ai/oauth/start",
+    });
+    expect(getClaudeCodeAuthStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app/api/auth/claudecode/exchange-route.test.ts
+++ b/tests/app/api/auth/claudecode/exchange-route.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  awaitClaudeLoginCompletion,
+  getClaudeCodeAuthStatus,
+  getClaudeLoginState,
+  submitClaudeLoginCode,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
+} = vi.hoisted(() => ({
+  awaitClaudeLoginCompletion: vi.fn(),
+  getClaudeCodeAuthStatus: vi.fn(),
+  getClaudeLoginState: vi.fn(),
+  submitClaudeLoginCode: vi.fn(),
+  verifyClaudeCodeAuthenticatedAfterDarioLogin: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/claudecode-auth", () => ({
+  getClaudeCodeAuthStatus,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
+}));
+
+vi.mock("@/lib/ai/providers/dario/login", () => ({
+  awaitClaudeLoginCompletion,
+  getClaudeLoginState,
+  submitClaudeLoginCode,
+}));
+
+import { POST } from "@/app/api/auth/claudecode/exchange/route";
+
+function request(code: string): Request {
+  return new Request("http://localhost/api/auth/claudecode/exchange", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code }),
+  });
+}
+
+describe("POST /api/auth/claudecode/exchange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClaudeCodeAuthStatus.mockResolvedValue({ authenticated: false });
+    getClaudeLoginState.mockReturnValue({
+      active: true,
+      status: "pending",
+      url: "https://claude.ai/oauth",
+      output: [],
+    });
+    submitClaudeLoginCode.mockImplementation(() => undefined);
+    awaitClaudeLoginCompletion.mockResolvedValue({
+      active: false,
+      status: "success",
+      url: null,
+      output: ["Login successful!"],
+    });
+    verifyClaudeCodeAuthenticatedAfterDarioLogin.mockResolvedValue({
+      authenticated: true,
+      output: ["Login successful!"],
+    });
+  });
+
+  it("short-circuits when already authenticated", async () => {
+    getClaudeCodeAuthStatus.mockResolvedValueOnce({ authenticated: true, output: ["already authed"] });
+
+    const response = await POST(request("ignored"));
+    const body = await response.json();
+
+    expect(body).toMatchObject({ success: true, authenticated: true, output: ["already authed"] });
+    expect(getClaudeLoginState).not.toHaveBeenCalled();
+    expect(submitClaudeLoginCode).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when no active Dario OAuth session exists", async () => {
+    getClaudeLoginState.mockReturnValueOnce(null);
+
+    const response = await POST(request("abc"));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toMatchObject({ success: false, authenticated: false });
+    expect(submitClaudeLoginCode).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty authorization code", async () => {
+    submitClaudeLoginCode.mockImplementationOnce(() => {
+      throw new Error("Paste the authorization code from the Claude login page.");
+    });
+
+    const response = await POST(request(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      authenticated: false,
+      error: "Paste the authorization code from the Claude login page.",
+    });
+    expect(awaitClaudeLoginCompletion).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the login session expires before submit", async () => {
+    submitClaudeLoginCode.mockImplementationOnce(() => {
+      throw new Error("No active Dario OAuth login. Click 'Login with Claude' to start a new flow.");
+    });
+
+    const response = await POST(request("abc"));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toMatchObject({
+      success: false,
+      authenticated: false,
+      error: "No active Dario OAuth login. Click 'Login with Claude' to start a new flow.",
+    });
+    expect(awaitClaudeLoginCompletion).not.toHaveBeenCalled();
+  });
+
+  it("verifies Dario sidecar readiness after login completion", async () => {
+    const response = await POST(request("abc"));
+    const body = await response.json();
+
+    expect(awaitClaudeLoginCompletion).toHaveBeenCalledWith(30_000);
+    expect(verifyClaudeCodeAuthenticatedAfterDarioLogin).toHaveBeenCalledWith(["Login successful!"]);
+    expect(getClaudeCodeAuthStatus).toHaveBeenCalledTimes(1);
+    expect(body).toMatchObject({
+      success: true,
+      authenticated: true,
+      output: ["Login successful!"],
+    });
+  });
+
+  it("returns the verified readiness error when sidecar verification fails", async () => {
+    verifyClaudeCodeAuthenticatedAfterDarioLogin.mockResolvedValueOnce({
+      authenticated: false,
+      output: ["Login successful!"],
+      error: "Dario status endpoint returned HTTP 503",
+    });
+
+    const response = await POST(request("abc"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: false,
+      authenticated: false,
+      error: "Dario status endpoint returned HTTP 503",
+      output: ["Login successful!"],
+    });
+  });
+});

--- a/tests/lib/ai/providers/claudecode-client.test.ts
+++ b/tests/lib/ai/providers/claudecode-client.test.ts
@@ -1,14 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { ensureDarioSidecarReady } = vi.hoisted(() => ({
+const {
+  createAnthropicMock,
+  ensureDarioConfig,
+  ensureDarioSidecarReady,
+  getDarioBaseUrl,
+} = vi.hoisted(() => ({
+  createAnthropicMock: vi.fn(),
+  ensureDarioConfig: vi.fn(() => ({
+    dir: "/tmp/selene-dario",
+    apiKey: "selene-dario-test-key",
+    port: 8575,
+    host: "localhost",
+  })),
   ensureDarioSidecarReady: vi.fn(async () => ({
     port: 8575,
     apiKey: "selene-dario-test-key",
-    baseUrl: "http://127.0.0.1:8575/v1",
+    baseUrl: "http://localhost:8575/v1",
   })),
+  getDarioBaseUrl: vi.fn((port = 8575, host = "127.0.0.1") => `http://${host}:${port}/v1`),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: createAnthropicMock,
+}));
+
+vi.mock("@/lib/ai/providers/dario/config", () => ({
+  ensureDarioConfig,
+  getDarioBaseUrl,
 }));
 
 vi.mock("@/lib/ai/providers/dario/sidecar", () => ({
@@ -23,21 +42,13 @@ import {
 } from "@/lib/ai/providers/claudecode-client";
 
 describe("claudecode-client", () => {
-  let dataDir: string;
-  let prev: string | undefined;
-
   beforeEach(() => {
     invalidateClaudeCodeProvider();
+    createAnthropicMock.mockReset();
+    createAnthropicMock.mockImplementation(() => (modelId: string) => ({ modelId }));
+    ensureDarioConfig.mockClear();
     ensureDarioSidecarReady.mockClear();
-    dataDir = mkdtempSync(join(tmpdir(), "selene-cc-client-"));
-    prev = process.env.LOCAL_DATA_PATH;
-    process.env.LOCAL_DATA_PATH = dataDir;
-  });
-
-  afterEach(() => {
-    rmSync(dataDir, { recursive: true, force: true });
-    if (prev === undefined) delete process.env.LOCAL_DATA_PATH;
-    else process.env.LOCAL_DATA_PATH = prev;
+    getDarioBaseUrl.mockClear();
   });
 
   it("constructs a provider lazily and returns a LanguageModel per modelId", () => {
@@ -46,8 +57,17 @@ describe("claudecode-client", () => {
 
     const model = provider("claude-opus-4-7");
     expect(model).toBeTruthy();
-    // The AI SDK Anthropic provider tags LanguageModel instances with modelId.
     expect((model as { modelId?: string }).modelId).toBe("claude-opus-4-7");
+  });
+
+  it("builds the Anthropic client with the configured Dario host", () => {
+    createClaudeCodeProvider();
+
+    expect(getDarioBaseUrl).toHaveBeenCalledWith(8575, "localhost");
+    expect(createAnthropicMock).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: "selene-dario-test-key",
+      baseURL: "http://localhost:8575/v1",
+    }));
   });
 
   it("does not boot Dario at construction time (lazy boot via fetch)", () => {
@@ -61,11 +81,13 @@ describe("claudecode-client", () => {
     const ma = a("claude-opus-4-7") as { modelId?: string };
     const mb = b("claude-opus-4-7") as { modelId?: string };
     expect(ma.modelId).toBe(mb.modelId);
+    expect(createAnthropicMock).toHaveBeenCalledTimes(1);
   });
 
   it("invalidateClaudeCodeProvider clears the cache (next call rebuilds)", () => {
     createClaudeCodeProvider();
     invalidateClaudeCodeProvider();
     expect(() => createClaudeCodeProvider()).not.toThrow();
+    expect(createAnthropicMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/lib/ai/providers/claudecode-client.test.ts
+++ b/tests/lib/ai/providers/claudecode-client.test.ts
@@ -3,18 +3,18 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const { ensureSidecarReady } = vi.hoisted(() => ({
-  ensureSidecarReady: vi.fn(async () => ({
-    port: 8317,
-    apiKey: "selene-test-key",
-    baseUrl: "http://127.0.0.1:8317/v1",
+const { ensureDarioSidecarReady } = vi.hoisted(() => ({
+  ensureDarioSidecarReady: vi.fn(async () => ({
+    port: 8575,
+    apiKey: "selene-dario-test-key",
+    baseUrl: "http://127.0.0.1:8575/v1",
   })),
 }));
 
-vi.mock("@/lib/ai/providers/cliproxy/sidecar", () => ({
-  ensureSidecarReady,
-  stopSidecar: vi.fn(),
-  isSidecarReady: vi.fn(() => true),
+vi.mock("@/lib/ai/providers/dario/sidecar", () => ({
+  ensureDarioSidecarReady,
+  stopDarioSidecar: vi.fn(),
+  isDarioSidecarReady: vi.fn(() => true),
 }));
 
 import {
@@ -28,7 +28,7 @@ describe("claudecode-client", () => {
 
   beforeEach(() => {
     invalidateClaudeCodeProvider();
-    ensureSidecarReady.mockClear();
+    ensureDarioSidecarReady.mockClear();
     dataDir = mkdtempSync(join(tmpdir(), "selene-cc-client-"));
     prev = process.env.LOCAL_DATA_PATH;
     process.env.LOCAL_DATA_PATH = dataDir;
@@ -50,16 +50,14 @@ describe("claudecode-client", () => {
     expect((model as { modelId?: string }).modelId).toBe("claude-opus-4-7");
   });
 
-  it("does not boot the sidecar at construction time (lazy boot via fetch)", () => {
+  it("does not boot Dario at construction time (lazy boot via fetch)", () => {
     createClaudeCodeProvider();
-    expect(ensureSidecarReady).not.toHaveBeenCalled();
+    expect(ensureDarioSidecarReady).not.toHaveBeenCalled();
   });
 
   it("caches the provider across calls so two calls share one instance", () => {
     const a = createClaudeCodeProvider();
     const b = createClaudeCodeProvider();
-    // Both factories return functions; calling each with the same modelId
-    // should produce models pointing at the same underlying provider.
     const ma = a("claude-opus-4-7") as { modelId?: string };
     const mb = b("claude-opus-4-7") as { modelId?: string };
     expect(ma.modelId).toBe(mb.modelId);
@@ -68,7 +66,6 @@ describe("claudecode-client", () => {
   it("invalidateClaudeCodeProvider clears the cache (next call rebuilds)", () => {
     createClaudeCodeProvider();
     invalidateClaudeCodeProvider();
-    // No throw + no error is the contract; re-calling rebuilds without error.
     expect(() => createClaudeCodeProvider()).not.toThrow();
   });
 });

--- a/tests/lib/ai/providers/dario/binary.test.ts
+++ b/tests/lib/ai/providers/dario/binary.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("dario/binary", () => {
+  let tmp: string;
+  let previousBin: string | undefined;
+  let previousResourcesPath: string | undefined;
+  let previousElectronIsDev: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    tmp = join(tmpdir(), `selene-dario-binary-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(tmp, { recursive: true });
+    previousBin = process.env.SELENE_DARIO_BIN;
+    previousResourcesPath = process.env.ELECTRON_RESOURCES_PATH;
+    previousElectronIsDev = process.env.ELECTRON_IS_DEV;
+    delete process.env.SELENE_DARIO_BIN;
+    delete process.env.ELECTRON_RESOURCES_PATH;
+    delete process.env.ELECTRON_IS_DEV;
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (previousBin === undefined) delete process.env.SELENE_DARIO_BIN;
+    else process.env.SELENE_DARIO_BIN = previousBin;
+    if (previousResourcesPath === undefined) delete process.env.ELECTRON_RESOURCES_PATH;
+    else process.env.ELECTRON_RESOURCES_PATH = previousResourcesPath;
+    if (previousElectronIsDev === undefined) delete process.env.ELECTRON_IS_DEV;
+    else process.env.ELECTRON_IS_DEV = previousElectronIsDev;
+  });
+
+  function createPackagedDarioRuntime(): { nodePath: string; cliPath: string } {
+    const nodeName = process.platform === "win32" ? "node.exe" : "node";
+    const nodePath = join(tmp, "standalone", "node_modules", ".bin", nodeName);
+    const cliPath = join(tmp, "standalone", "node_modules", "@askalf", "dario", "dist", "cli.js");
+    mkdirSync(join(nodePath, ".."), { recursive: true });
+    mkdirSync(join(cliPath, ".."), { recursive: true });
+    writeFileSync(nodePath, "node");
+    writeFileSync(cliPath, "#!/usr/bin/env node\n");
+    return { nodePath, cliPath };
+  }
+
+  it("uses the packaged Dario CLI and bundled Node when Electron resources are present", async () => {
+    const { nodePath, cliPath } = createPackagedDarioRuntime();
+    process.env.ELECTRON_RESOURCES_PATH = tmp;
+
+    const { resolveDarioCommand, withDarioCommandArgs } = await import("@/lib/ai/providers/dario/binary");
+    const resolution = resolveDarioCommand();
+
+    expect(resolution.source).toBe("packaged");
+    expect(resolution.command).toBe(nodePath);
+    expect(resolution.argsPrefix).toEqual([cliPath]);
+    expect(withDarioCommandArgs(resolution, ["proxy"])).toEqual([cliPath, "proxy"]);
+  });
+
+  it("fails clearly when a packaged app is missing the bundled Dario runtime", async () => {
+    process.env.ELECTRON_RESOURCES_PATH = tmp;
+
+    const { resolveDarioCommand } = await import("@/lib/ai/providers/dario/binary");
+
+    expect(() => resolveDarioCommand()).toThrow(/Bundled Dario runtime is missing/);
+  });
+
+  it("lets SELENE_DARIO_BIN override packaged resolution", async () => {
+    process.env.ELECTRON_RESOURCES_PATH = tmp;
+    process.env.SELENE_DARIO_BIN = "/custom/dario";
+
+    const { resolveDarioCommand } = await import("@/lib/ai/providers/dario/binary");
+    const resolution = resolveDarioCommand();
+
+    expect(resolution).toMatchObject({
+      source: "override",
+      command: "/custom/dario",
+      argsPrefix: [],
+    });
+  });
+
+  it("uses the installed npm dependency in development before falling back to PATH", async () => {
+    const { resolveDarioCommand } = await import("@/lib/ai/providers/dario/binary");
+    const resolution = resolveDarioCommand();
+
+    expect(resolution.source).toBe("dependency");
+    expect(resolution.command).toBe(process.execPath);
+    expect(resolution.argsPrefix[0]).toMatch(/node_modules[/\\]@askalf[/\\]dario[/\\]dist[/\\]cli\.js$/);
+  });
+});

--- a/tests/lib/ai/providers/dario/config.test.ts
+++ b/tests/lib/ai/providers/dario/config.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DARIO_DEFAULT_PORT,
+  DARIO_HOST,
+  ensureDarioConfig,
+  getDarioBaseUrl,
+  getSeleneDarioDir,
+} from "@/lib/ai/providers/dario/config";
+
+describe("dario/config", () => {
+  let dataDir: string;
+  let prevDataPath: string | undefined;
+  let prevPort: string | undefined;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "selene-dario-cfg-"));
+    prevDataPath = process.env.LOCAL_DATA_PATH;
+    prevPort = process.env.SELENE_DARIO_PORT;
+    process.env.LOCAL_DATA_PATH = dataDir;
+    delete process.env.SELENE_DARIO_PORT;
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    if (prevDataPath === undefined) delete process.env.LOCAL_DATA_PATH;
+    else process.env.LOCAL_DATA_PATH = prevDataPath;
+    if (prevPort === undefined) delete process.env.SELENE_DARIO_PORT;
+    else process.env.SELENE_DARIO_PORT = prevPort;
+  });
+
+  it("generates a stable Selene-owned Dario API key", () => {
+    const first = ensureDarioConfig();
+    const second = ensureDarioConfig();
+
+    expect(first.dir).toBe(join(dataDir, "dario"));
+    expect(first.port).toBe(DARIO_DEFAULT_PORT);
+    expect(first.host).toBe(DARIO_HOST);
+    expect(first.apiKey).toMatch(/^selene-dario-[a-f0-9]{48}$/);
+    expect(second.apiKey).toBe(first.apiKey);
+    expect(readFileSync(join(first.dir, "api-key"), "utf8").trim()).toBe(first.apiKey);
+  });
+
+  it("honors LOCAL_DATA_PATH for the Dario runtime directory", () => {
+    expect(getSeleneDarioDir()).toBe(join(dataDir, "dario"));
+  });
+
+  it("honors SELENE_DARIO_PORT when valid", () => {
+    process.env.SELENE_DARIO_PORT = "4567";
+    expect(ensureDarioConfig().port).toBe(4567);
+  });
+
+  it("falls back to the default port when SELENE_DARIO_PORT is invalid", () => {
+    process.env.SELENE_DARIO_PORT = "not-a-port";
+    expect(ensureDarioConfig().port).toBe(DARIO_DEFAULT_PORT);
+  });
+
+  it("uses a default port that does not collide with packaged Electron's Next server", () => {
+    expect(DARIO_DEFAULT_PORT).toBe(8575);
+  });
+
+  it("builds the Anthropic-compatible base URL with /v1", () => {
+    expect(getDarioBaseUrl(DARIO_DEFAULT_PORT)).toBe("http://127.0.0.1:8575/v1");
+  });
+});

--- a/tests/lib/ai/providers/dario/login.test.ts
+++ b/tests/lib/ai/providers/dario/login.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { spawnMock, stopDarioSidecarAndWait } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  stopDarioSidecarAndWait: vi.fn(async () => undefined),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock("@/lib/ai/providers/dario/sidecar", () => ({
+  stopDarioSidecarAndWait,
+}));
+
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: ReturnType<typeof vi.fn> };
+  exitCode: number | null;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = { write: vi.fn() };
+  child.exitCode = null;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+    return true;
+  });
+  return child;
+}
+
+describe("dario/login output capture", () => {
+  let dataDir: string;
+  let previousDataPath: string | undefined;
+  let previousBin: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    spawnMock.mockReset();
+    stopDarioSidecarAndWait.mockClear();
+    delete (globalThis as any).__seleneDarioClaudeLogin;
+
+    dataDir = mkdtempSync(join(tmpdir(), "selene-dario-login-"));
+    previousDataPath = process.env.LOCAL_DATA_PATH;
+    previousBin = process.env.SELENE_DARIO_BIN;
+    process.env.LOCAL_DATA_PATH = dataDir;
+    process.env.SELENE_DARIO_BIN = "dario-test";
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    if (previousDataPath === undefined) delete process.env.LOCAL_DATA_PATH;
+    else process.env.LOCAL_DATA_PATH = previousDataPath;
+    if (previousBin === undefined) delete process.env.SELENE_DARIO_BIN;
+    else process.env.SELENE_DARIO_BIN = previousBin;
+    delete (globalThis as any).__seleneDarioClaudeLogin;
+  });
+
+  it("captures an OAuth URL split across stdout chunks", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValueOnce(child);
+    const { startClaudeLogin } = await import("@/lib/ai/providers/dario/login");
+
+    const started = startClaudeLogin();
+    child.stdout.emit("data", Buffer.from("Open https://claude.ai/oa"));
+    child.stdout.emit("data", Buffer.from("uth?code=abc\n"));
+
+    const result = await started;
+
+    expect(result.url).toBe("https://claude.ai/oauth?code=abc");
+    expect(result.output).toEqual(["Open https://claude.ai/oauth?code=abc"]);
+  });
+
+  it("detects successful login output split across chunks", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValueOnce(child);
+    const { startClaudeLogin } = await import("@/lib/ai/providers/dario/login");
+
+    const started = startClaudeLogin();
+    child.stdout.emit("data", Buffer.from("Login suc"));
+    child.stdout.emit("data", Buffer.from("cessful!\n"));
+
+    const result = await started;
+
+    expect(result.output).toEqual(["Login successful!"]);
+    expect(stopDarioSidecarAndWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures command output split across chunks as one line", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValueOnce(child);
+    const { refreshClaudeLogin } = await import("@/lib/ai/providers/dario/login");
+
+    const refreshed = refreshClaudeLogin();
+    child.stdout.emit("data", Buffer.from("Refresh suc"));
+    child.stdout.emit("data", Buffer.from("cessful!\n"));
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+
+    const result = await refreshed;
+
+    expect(result.status).toBe("success");
+    expect(result.output).toEqual(["Refresh successful!"]);
+    expect(stopDarioSidecarAndWait).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/lib/ai/providers/dario/sidecar.test.ts
+++ b/tests/lib/ai/providers/dario/sidecar.test.ts
@@ -172,6 +172,27 @@ describe("dario/sidecar", () => {
     expect(ready.port).toBe(4568);
   });
 
+  it("does not retry indefinitely when spawned dario exits during startup", async () => {
+    spawnMock.mockImplementation(() => {
+      const child = makeChild();
+      setTimeout(() => {
+        child.exitCode = 0;
+        child.emit("exit", 0, null);
+      }, 0);
+      return child;
+    });
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) return new Response("{}", { status: 200 });
+      if (url.endsWith("/status")) return darioStatusResponse();
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const { ensureDarioSidecarReady } = await import("@/lib/ai/providers/dario/sidecar");
+    await expect(ensureDarioSidecarReady()).rejects.toThrow(/exited during startup after retry/);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
   it("fails when /status rejects Selene's API key", async () => {
     const child = makeChild();
     spawnMock.mockReturnValue(child);

--- a/tests/lib/ai/providers/dario/sidecar.test.ts
+++ b/tests/lib/ai/providers/dario/sidecar.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+type FakeChild = EventEmitter & {
+  stdout: NodeJS.ReadableStream;
+  stderr: NodeJS.ReadableStream;
+  exitCode: number | null;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function makeStream(): NodeJS.ReadableStream {
+  const stream = new EventEmitter() as NodeJS.ReadableStream & { setEncoding: ReturnType<typeof vi.fn> };
+  stream.setEncoding = vi.fn();
+  return stream;
+}
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = makeStream();
+  child.stderr = makeStream();
+  child.exitCode = null;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+    return true;
+  });
+  return child;
+}
+
+function darioStatusResponse(status = 200): Response {
+  return new Response(JSON.stringify({ authenticated: false, status: "none" }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("dario/sidecar", () => {
+  let dataDir: string;
+  let previousDataPath: string | undefined;
+  let previousPort: string | undefined;
+  let previousBin: string | undefined;
+  let previousAllowExternal: string | undefined;
+  let previousFetch: typeof globalThis.fetch;
+  let previousAnthropicUpstream: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    spawnMock.mockReset();
+    delete (globalThis as any).__seleneDarioSidecar;
+    delete (globalThis as any).__seleneDarioSidecarStart;
+    delete (globalThis as any).__seleneDarioExitHooked;
+
+    dataDir = mkdtempSync(join(tmpdir(), "selene-dario-sidecar-"));
+    previousDataPath = process.env.LOCAL_DATA_PATH;
+    previousPort = process.env.SELENE_DARIO_PORT;
+    previousBin = process.env.SELENE_DARIO_BIN;
+    previousAllowExternal = process.env.SELENE_DARIO_ALLOW_EXTERNAL;
+    previousAnthropicUpstream = process.env.ANTHROPIC_UPSTREAM_API_KEY;
+    previousFetch = globalThis.fetch;
+
+    process.env.LOCAL_DATA_PATH = dataDir;
+    process.env.SELENE_DARIO_PORT = "4568";
+    process.env.SELENE_DARIO_BIN = "dario-test";
+    process.env.ANTHROPIC_UPSTREAM_API_KEY = "must-not-leak";
+    delete process.env.SELENE_DARIO_ALLOW_EXTERNAL;
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    if (previousDataPath === undefined) delete process.env.LOCAL_DATA_PATH;
+    else process.env.LOCAL_DATA_PATH = previousDataPath;
+    if (previousPort === undefined) delete process.env.SELENE_DARIO_PORT;
+    else process.env.SELENE_DARIO_PORT = previousPort;
+    if (previousBin === undefined) delete process.env.SELENE_DARIO_BIN;
+    else process.env.SELENE_DARIO_BIN = previousBin;
+    if (previousAllowExternal === undefined) delete process.env.SELENE_DARIO_ALLOW_EXTERNAL;
+    else process.env.SELENE_DARIO_ALLOW_EXTERNAL = previousAllowExternal;
+    if (previousAnthropicUpstream === undefined) delete process.env.ANTHROPIC_UPSTREAM_API_KEY;
+    else process.env.ANTHROPIC_UPSTREAM_API_KEY = previousAnthropicUpstream;
+    globalThis.fetch = previousFetch;
+    delete (globalThis as any).__seleneDarioSidecar;
+    delete (globalThis as any).__seleneDarioSidecarStart;
+    delete (globalThis as any).__seleneDarioExitHooked;
+  });
+
+  it("spawns dario proxy with Selene-owned env and treats /health 503 as listening", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) return new Response("{}", { status: 503 });
+      if (url.endsWith("/status")) return darioStatusResponse();
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const { ensureDarioSidecarReady } = await import("@/lib/ai/providers/dario/sidecar");
+    const ready = await ensureDarioSidecarReady();
+
+    expect(ready.port).toBe(4568);
+    expect(ready.baseUrl).toBe("http://127.0.0.1:4568/v1");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [binary, args, options] = spawnMock.mock.calls[0];
+    expect(binary).toBe("dario-test");
+    expect(args).toEqual(["proxy", "--port=4568", "--host=127.0.0.1"]);
+    expect(options.env.DARIO_API_KEY).toMatch(/^selene-dario-/);
+    expect(options.env.DARIO_PORT).toBe("4568");
+    expect(options.env.DARIO_HOST).toBe("127.0.0.1");
+    expect(options.env.ANTHROPIC_UPSTREAM_API_KEY).toBeUndefined();
+  });
+
+  it("single-flights concurrent startup calls", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+    let releaseHealth!: () => void;
+    const healthGate = new Promise<void>((resolve) => {
+      releaseHealth = resolve;
+    });
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) {
+        await healthGate;
+        return new Response("{}", { status: 200 });
+      }
+      if (url.endsWith("/status")) return darioStatusResponse();
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const { ensureDarioSidecarReady } = await import("@/lib/ai/providers/dario/sidecar");
+    const first = ensureDarioSidecarReady();
+    const second = ensureDarioSidecarReady();
+    releaseHealth();
+
+    await Promise.all([first, second]);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once when the spawned dario exits during startup", async () => {
+    const firstChild = makeChild();
+    const retryChild = makeChild();
+    spawnMock
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(retryChild);
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) return new Response("{}", { status: 200 });
+      if (url.endsWith("/status")) return darioStatusResponse();
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const { ensureDarioSidecarReady } = await import("@/lib/ai/providers/dario/sidecar");
+    const promise = ensureDarioSidecarReady();
+    // first child detects port taken and exits
+    firstChild.exitCode = 0;
+    firstChild.emit("exit", 0, null);
+
+    const ready = await promise;
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(ready.port).toBe(4568);
+  });
+
+  it("fails when /status rejects Selene's API key", async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) return new Response("{}", { status: 200 });
+      if (url.endsWith("/status")) return darioStatusResponse(401);
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    const { ensureDarioSidecarReady } = await import("@/lib/ai/providers/dario/sidecar");
+    await expect(ensureDarioSidecarReady()).rejects.toThrow(/rejected Selene's API key/);
+  });
+});

--- a/tests/lib/ai/providers/dario/status.test.ts
+++ b/tests/lib/ai/providers/dario/status.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { getStatusMock, ensureDarioSidecarReadyMock } = vi.hoisted(() => ({
+  getStatusMock: vi.fn(),
+  ensureDarioSidecarReadyMock: vi.fn(),
+}));
+
+vi.mock("@askalf/dario", () => ({
+  getStatus: getStatusMock,
+}));
+
+vi.mock("@/lib/ai/providers/dario/sidecar", () => ({
+  ensureDarioSidecarReady: ensureDarioSidecarReadyMock,
+}));
+
+describe("dario/status", () => {
+  let dataDir: string;
+  let previousDataPath: string | undefined;
+  let previousPort: string | undefined;
+  let previousFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    getStatusMock.mockReset();
+    ensureDarioSidecarReadyMock.mockReset();
+    getStatusMock.mockResolvedValue({ authenticated: false, status: "none" });
+    ensureDarioSidecarReadyMock.mockResolvedValue({ port: 4569, apiKey: "test-key", baseUrl: "http://127.0.0.1:4569/v1" });
+    previousFetch = globalThis.fetch;
+    previousDataPath = process.env.LOCAL_DATA_PATH;
+    previousPort = process.env.SELENE_DARIO_PORT;
+    dataDir = mkdtempSync(join(tmpdir(), "selene-dario-status-"));
+    process.env.LOCAL_DATA_PATH = dataDir;
+    process.env.SELENE_DARIO_PORT = "4569";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = previousFetch;
+    rmSync(dataDir, { recursive: true, force: true });
+    if (previousDataPath === undefined) delete process.env.LOCAL_DATA_PATH;
+    else process.env.LOCAL_DATA_PATH = previousDataPath;
+    if (previousPort === undefined) delete process.env.SELENE_DARIO_PORT;
+    else process.env.SELENE_DARIO_PORT = previousPort;
+  });
+
+  it("reads Dario OAuth status directly by default without starting the sidecar", async () => {
+    getStatusMock.mockResolvedValueOnce({ authenticated: true, status: "healthy" });
+
+    const { fetchDarioStatus } = await import("@/lib/ai/providers/dario/status");
+    const status = await fetchDarioStatus();
+
+    expect(status).toEqual({ authenticated: true, status: "healthy" });
+    expect(ensureDarioSidecarReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("checks authenticated /status through the sidecar when ensureReady is requested", async () => {
+    globalThis.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({ Authorization: expect.stringMatching(/^Bearer selene-dario-/) });
+      return new Response(JSON.stringify({ authenticated: true, status: "healthy" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { fetchDarioStatus } = await import("@/lib/ai/providers/dario/status");
+    const status = await fetchDarioStatus({ ensureReady: true });
+
+    expect(status.authenticated).toBe(true);
+    expect(ensureDarioSidecarReadyMock).toHaveBeenCalledTimes(1);
+    expect(getStatusMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/auth/claudecode-auth.test.ts
+++ b/tests/lib/auth/claudecode-auth.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
-const settingsStore = { current: {} as Record<string, unknown> };
+const settingsStore = { current: {} as Record<string, any> };
+
+const { fetchDarioStatus, getClaudeLoginState, logoutClaudeLogin } = vi.hoisted(() => ({
+  fetchDarioStatus: vi.fn(),
+  getClaudeLoginState: vi.fn(() => null),
+  logoutClaudeLogin: vi.fn(async () => ({
+    active: false,
+    status: "success" as const,
+    url: null,
+    output: ["logged out"],
+  })),
+}));
 
 vi.mock("@/lib/settings/settings-manager", () => ({
   loadSettings: vi.fn(() => settingsStore.current),
@@ -12,8 +20,15 @@ vi.mock("@/lib/settings/settings-manager", () => ({
   }),
 }));
 
-vi.mock("@/lib/ai/providers/cliproxy/login", () => ({
-  getClaudeLoginState: vi.fn(() => null),
+vi.mock("@/lib/ai/providers/dario/status", () => ({
+  fetchDarioStatus,
+  isDarioStatusUsable: (status: { authenticated: boolean; status: string; canRefresh?: boolean }) =>
+    status.authenticated || (status.status === "expired" && status.canRefresh === true),
+}));
+
+vi.mock("@/lib/ai/providers/dario/login", () => ({
+  getClaudeLoginState,
+  logoutClaudeLogin,
 }));
 
 import {
@@ -22,63 +37,128 @@ import {
   getClaudeCodeAuthStatus,
   invalidateClaudeCodeAuthCache,
   isClaudeCodeAuthenticated,
+  verifyClaudeCodeAuthenticatedAfterDarioLogin,
 } from "@/lib/auth/claudecode-auth";
 
-describe("claudecode-auth (CLIProxyAPI-backed)", () => {
-  let authDir: string;
-  let prev: string | undefined;
-
+describe("claudecode-auth (Dario-backed)", () => {
   beforeEach(() => {
     settingsStore.current = {};
     invalidateClaudeCodeAuthCache();
-    authDir = mkdtempSync(join(tmpdir(), "selene-ccauth-"));
-    prev = process.env.SELENE_CLIPROXY_AUTH_DIR;
-    process.env.SELENE_CLIPROXY_AUTH_DIR = authDir;
+    fetchDarioStatus.mockResolvedValue({ authenticated: false, status: "none" });
+    getClaudeLoginState.mockReturnValue(null);
+    logoutClaudeLogin.mockResolvedValue({
+      active: false,
+      status: "success",
+      url: null,
+      output: ["logged out"],
+    });
   });
 
   afterEach(() => {
-    rmSync(authDir, { recursive: true, force: true });
-    if (prev === undefined) delete process.env.SELENE_CLIPROXY_AUTH_DIR;
-    else process.env.SELENE_CLIPROXY_AUTH_DIR = prev;
+    vi.clearAllMocks();
   });
 
-  it("reports unauthenticated when no credential file is present", async () => {
+  it("reports unauthenticated when Dario has no OAuth credentials", async () => {
     const status = await getClaudeCodeAuthStatus();
     expect(status.authenticated).toBe(false);
     expect(status.email).toBeUndefined();
-    expect(status.tokenSource).toBe("cliproxyapi-oauth");
+    expect(status.tokenSource).toBe("dario-oauth");
+    expect(status.apiKeySource).toBe("dario-local-proxy");
   });
 
-  it("returns authenticated with email when a claude-*.json exists", async () => {
-    writeFileSync(join(authDir, "claude-umut@rltm.ai.json"), "{}");
+  it("returns authenticated when Dario reports healthy credentials", async () => {
+    fetchDarioStatus.mockResolvedValue({
+      authenticated: true,
+      status: "healthy",
+      expiresAt: 1900000000000,
+      expiresIn: "2h 0m",
+    });
 
     const status = await getClaudeCodeAuthStatus();
     expect(status.authenticated).toBe(true);
-    expect(status.email).toBe("umut@rltm.ai");
-    expect(status.account).toBe("umut@rltm.ai");
-
+    expect(status.email).toBeUndefined();
+    expect(status.expiresAt).toBe(1900000000000);
     expect(await isClaudeCodeAuthenticated()).toBe(true);
   });
 
+  it("treats expired-but-refreshable Dario credentials as usable", async () => {
+    fetchDarioStatus.mockResolvedValue({
+      authenticated: false,
+      status: "expired",
+      canRefresh: true,
+      expiresAt: 1,
+    });
+
+    const status = await getClaudeCodeAuthStatus();
+    expect(status.authenticated).toBe(true);
+    expect(status.error).toBeUndefined();
+  });
+
   it("persists the snapshot so a sync read after refresh matches", async () => {
-    writeFileSync(join(authDir, "claude-foo@bar.com.json"), "{}");
+    fetchDarioStatus.mockResolvedValue({
+      authenticated: true,
+      status: "expiring",
+      expiresAt: 1900000000000,
+      expiresIn: "10m",
+    });
+
     await getClaudeCodeAuthStatus();
 
     const state = getClaudeCodeAuthState();
     expect(state.isAuthenticated).toBe(true);
-    expect(state.email).toBe("foo@bar.com");
-    expect(state.tokenSource).toBe("cliproxyapi-oauth");
+    expect(state.email).toBeUndefined();
+    expect(state.expiresAt).toBe(1900000000000);
+    expect(state.tokenSource).toBe("dario-oauth");
   });
 
-  it("clearClaudeCodeAuth deletes credentials and resets the snapshot", async () => {
-    writeFileSync(join(authDir, "claude-x@y.com.json"), "{}");
-    await getClaudeCodeAuthStatus(); // populate cache
+  it("does not trust successful Dario login output when /status is stale", async () => {
+    fetchDarioStatus.mockResolvedValue({ authenticated: false, status: "none" });
+    getClaudeLoginState.mockReturnValue({
+      active: false,
+      status: "success",
+      url: null,
+      output: ["Found valid credentials. (--no-proxy / --manual: not starting proxy.)"],
+    });
+
+    const status = await getClaudeCodeAuthStatus();
+    expect(status.authenticated).toBe(false);
+    expect(getClaudeCodeAuthState().isAuthenticated).toBe(false);
+  });
+
+  it("verifies the Dario sidecar after successful login output before marking authenticated", async () => {
+    fetchDarioStatus.mockResolvedValue({ authenticated: true, status: "healthy" });
+
+    const status = await verifyClaudeCodeAuthenticatedAfterDarioLogin(["Found valid credentials. (--no-proxy / --manual: not starting proxy.)"]);
+
+    expect(fetchDarioStatus).toHaveBeenCalledWith({ ensureReady: true });
+    expect(status.authenticated).toBe(true);
+    expect(status.output).toEqual(["Found valid credentials. (--no-proxy / --manual: not starting proxy.)"]);
+    expect(getClaudeCodeAuthState().isAuthenticated).toBe(true);
+  });
+
+  it("surfaces broken Dario refresh errors", async () => {
+    fetchDarioStatus.mockResolvedValue({
+      authenticated: false,
+      status: "broken",
+      refreshFailures: 3,
+      lastRefreshError: "invalid_grant",
+    });
+
+    const status = await getClaudeCodeAuthStatus();
+    expect(status.authenticated).toBe(false);
+    expect(status.error).toContain("invalid_grant");
+  });
+
+  it("clearClaudeCodeAuth calls dario logout and resets the snapshot", async () => {
+    fetchDarioStatus.mockResolvedValue({ authenticated: true, status: "healthy" });
+    await getClaudeCodeAuthStatus();
     expect((await getClaudeCodeAuthStatus()).authenticated).toBe(true);
 
     await clearClaudeCodeAuth();
 
-    expect((await getClaudeCodeAuthStatus()).authenticated).toBe(false);
+    expect(logoutClaudeLogin).toHaveBeenCalledTimes(1);
     const state = getClaudeCodeAuthState();
     expect(state.isAuthenticated).toBe(false);
+    expect(state.tokenSource).toBe("dario-oauth");
   });
 });

--- a/tests/lib/auth/claudecode-auth.test.ts
+++ b/tests/lib/auth/claudecode-auth.test.ts
@@ -149,6 +149,17 @@ describe("claudecode-auth (Dario-backed)", () => {
     expect(status.error).toContain("invalid_grant");
   });
 
+  it("does not reset local auth state when dario logout fails", async () => {
+    fetchDarioStatus.mockResolvedValue({ authenticated: true, status: "healthy" });
+    await getClaudeCodeAuthStatus();
+    logoutClaudeLogin.mockRejectedValueOnce(new Error("logout failed"));
+
+    await expect(clearClaudeCodeAuth()).rejects.toThrow("logout failed");
+
+    expect(logoutClaudeLogin).toHaveBeenCalledTimes(1);
+    expect(getClaudeCodeAuthState().isAuthenticated).toBe(true);
+  });
+
   it("clearClaudeCodeAuth calls dario logout and resets the snapshot", async () => {
     fetchDarioStatus.mockResolvedValue({ authenticated: true, status: "healthy" });
     await getClaudeCodeAuthStatus();

--- a/tests/lib/context-window/context-window-fix-validation.test.ts
+++ b/tests/lib/context-window/context-window-fix-validation.test.ts
@@ -55,7 +55,7 @@ describe("Context Window Fix Validation", () => {
     });
   });
 
-  describe("Claude Model-Specific Configurations (200K)", () => {
+  describe("Claude Model-Specific Configurations", () => {
     const claude200KModels = [
       "claude-sonnet-4-5-20250929",
       "claude-haiku-4-5-20251001",
@@ -70,9 +70,18 @@ describe("Context Window Fix Validation", () => {
       });
     });
 
-    it("should configure claude-opus-4-6 with 1M context window", () => {
-      const config = getContextWindowConfig("claude-opus-4-6");
-      expect(config.maxTokens).toBe(1000000);
+    const claude1MModels = [
+      "claude-opus-4-8",
+      "claude-fable-5",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+    ];
+
+    claude1MModels.forEach((modelId) => {
+      it(`should configure ${modelId} with 1M context window`, () => {
+        const config = getContextWindowConfig(modelId, "claudecode");
+        expect(config.maxTokens).toBe(1000000);
+      });
     });
   });
 
@@ -186,9 +195,17 @@ describe("Context Window Fix Validation", () => {
         expect(config.maxTokens).toBe(200000);
       }
 
-      // claude-opus-4-6 has 1M context (model-catalog contextWindow: "1M")
-      const opusConfig = getContextWindowConfig("claude-opus-4-6");
-      expect(opusConfig.maxTokens).toBe(1000000);
+      // Claude Code flagship models have 1M context (model-catalog contextWindow: "1M")
+      const claude1MModels = [
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+      ];
+      for (const modelId of claude1MModels) {
+        const config = getContextWindowConfig(modelId, "claudecode");
+        expect(config.maxTokens).toBe(1000000);
+      }
     });
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: "node",
     setupFiles: ["./tests/setup.ts"],
     include: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"],
-    exclude: ["**/node_modules/**", "**/.next/**", "**/integration/**", "**/tmp-clawdbot/**", "**/.claude/worktrees/**"],
+    exclude: ["**/node_modules/**", "**/.next/**", "**/integration/**", "**/tmp-clawdbot/**", "**/.claude/worktrees/**", "**/.external/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary

Adds the Dario Claude Code authentication provider with full integration across the Selene platform.

## Changes

### New Provider (`lib/ai/providers/dario/`)
- **binary.ts** — Binary management for Dario sidecar
- **config.ts** — Provider configuration
- **environment.ts** — Environment variable handling
- **index.ts** — Provider entry point and exports
- **login.ts** — Login flow implementation
- **sidecar.ts** — Sidecar process management
- **status.ts** — Provider status checks

### API Routes
- Updated Claude Code auth routes (authorize, exchange, refresh) for Dario compatibility

### Core Integration
- `lib/auth/claudecode-auth.ts` — Extended auth logic for Dario provider
- `lib/auth/claudecode-models.ts` — Dario model definitions
- `lib/ai/providers/claudecode-client.ts` — Client-side Dario support
- `lib/config/model-catalog.ts` — Dario models in catalog
- `lib/context-window/provider-limits.ts` — Context window limits
- `lib/channels/manager.ts` — Channel manager integration

### UI
- Settings and onboarding components updated for Dario auth flow

### Tests
- `tests/lib/ai/providers/dario/` — Provider tests (binary, config, sidecar, status)
- `tests/app/api/auth/claudecode/` — Auth route tests
- Updated existing Claude Code auth and provider tests

### Chore
- `package.json` / `package-lock.json` — Updated dependencies
- Electron prepare and verify package scripts updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Fable 5 and Claude Opus 4.8 models with 1M context-window support.

* **Improvements**
  * Reworked Claude Code authentication to a new OAuth-backed flow with clearer open-URL + paste-code guidance.
  * Improved refresh/cancel behaviors for authentication attempts.
  * Enhanced user-facing error messages and fallback UI prompting diagnostics and retry when no auth URL is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->