### PR TITLE
feat(chromium): add responsive viewport controls

### DIFF
--- a/app/api/browser/[sessionId]/interact/route.ts
+++ b/app/api/browser/[sessionId]/interact/route.ts
@@ -211,6 +211,7 @@ export async function POST(
       success: true,
       durationMs,
       output: actionDescription,
+      viewport: activeSession.viewport,
       pageUrl,
       pageTitle,
       source: "user",
@@ -231,6 +232,7 @@ export async function POST(
     recordAction(sessionId, payload.type, payload as unknown as Record<string, unknown>, {
       success: false,
       durationMs,
+      viewport: activeSession.viewport,
       error: errorMsg,
       source: "user",
     });

--- a/app/api/browser/[sessionId]/replay/route.ts
+++ b/app/api/browser/[sessionId]/replay/route.ts
@@ -8,13 +8,21 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { peekHistory, buildReplayPlan, type SessionHistory } from "@/lib/browser/action-history";
-import { executeAction } from "@/lib/ai/tools/chromium-workspace-tool";
+import {
+  buildReplayPlan,
+  initHistory,
+  peekHistory,
+  recordAction,
+  type SessionHistory,
+} from "@/lib/browser/action-history";
+import {
+  executeAction,
+  type ActionType,
+  type ChromiumWorkspaceInput,
+} from "@/lib/ai/tools/chromium-workspace-tool";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-type ActionType = "open" | "navigate" | "click" | "type" | "snapshot" | "extract" | "evaluate" | "close" | "replay";
 
 export async function POST(
   req: NextRequest,
@@ -59,18 +67,41 @@ export async function POST(
   const replaySessionId = `replay-${sessionId}-${Date.now()}`;
 
   void (async () => {
+    initHistory(replaySessionId);
+
     for (const step of plan) {
       if (step.action === "close" || step.action === "replay") continue;
 
+      const sanitizedStepInput = { ...step.input };
+      delete sanitizedStepInput.action;
+      const replayInput = {
+        ...sanitizedStepInput,
+        action: step.action as ActionType,
+      } as ChromiumWorkspaceInput;
+      const startTime = Date.now();
+
       try {
-        await executeAction(
-          replaySessionId,
-          { action: step.action as ActionType, ...step.input },
-          30_000
-        );
+        const result = await executeAction(replaySessionId, replayInput, 30_000);
+        recordAction(replaySessionId, step.action, replayInput as unknown as Record<string, unknown>, {
+          success: true,
+          durationMs: Date.now() - startTime,
+          output: result.data,
+          viewport: result.viewport,
+          pageUrl: result.pageUrl,
+          pageTitle: result.pageTitle,
+          domSnapshot: result.domSnapshot,
+          source: "agent",
+        });
         // Small delay between actions for visual clarity
         await new Promise((r) => setTimeout(r, 500));
       } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        recordAction(replaySessionId, step.action, replayInput as unknown as Record<string, unknown>, {
+          success: false,
+          durationMs: Date.now() - startTime,
+          error: errorMsg,
+          source: "agent",
+        });
         console.error(`[Replay] Action ${step.action} failed:`, err);
         // Continue — best effort replay
       }

--- a/app/api/browser/[sessionId]/stream/route.ts
+++ b/app/api/browser/[sessionId]/stream/route.ts
@@ -64,7 +64,7 @@ export async function GET(
       // Send initial frame immediately if available
       const latest = getLatestFrame(sessionId);
       if (latest) {
-        const event = `data: ${JSON.stringify({ data: latest.data, ts: latest.receivedAt })}\n\n`;
+        const event = `data: ${JSON.stringify({ data: latest.data, ts: latest.receivedAt, metadata: latest.metadata })}\n\n`;
         controller.enqueue(encoder.encode(event));
       }
 
@@ -72,7 +72,7 @@ export async function GET(
       const unsubscribeFrames = subscribeToFrames(sessionId, (frame) => {
         if (closed) return;
         try {
-          const event = `data: ${JSON.stringify({ data: frame.data, ts: frame.receivedAt })}\n\n`;
+          const event = `data: ${JSON.stringify({ data: frame.data, ts: frame.receivedAt, metadata: frame.metadata })}\n\n`;
           controller.enqueue(encoder.encode(event));
         } catch {
           cleanup();
@@ -87,6 +87,7 @@ export async function GET(
             seq: record.seq,
             action: record.action,
             input: record.input,
+            viewport: record.viewport,
             source: record.source,
             timestamp: record.timestamp,
             success: record.success,

--- a/components/assistant-ui/chromium-workspace-tool-ui.tsx
+++ b/components/assistant-ui/chromium-workspace-tool-ui.tsx
@@ -37,6 +37,11 @@ interface ChromiumWorkspaceArgs {
   text?: string;
   expression?: string;
   timeout?: number;
+  viewportPreset?: string;
+  viewportWidth?: number;
+  viewportHeight?: number;
+  orientation?: "portrait" | "landscape";
+  resetViewport?: boolean;
 }
 
 interface HistorySummary {
@@ -58,6 +63,7 @@ interface ChromiumWorkspaceResult {
   data?: unknown;
   pageUrl?: string;
   pageTitle?: string;
+  viewport?: { width: number; height: number; orientation?: string; label?: string; preset?: string };
   error?: string;
 }
 
@@ -119,6 +125,21 @@ function humanizeSelector(selector: string): string {
   return selector.slice(0, 22) + "...";
 }
 
+function getViewportSummary(args?: ChromiumWorkspaceArgs): string {
+  if (!args) return "viewport";
+  if (args.resetViewport) return "default desktop viewport";
+  const preset = args.viewportPreset ? `${args.viewportPreset}` : "custom";
+  const size = args.viewportWidth && args.viewportHeight
+    ? `${args.viewportWidth}×${args.viewportHeight}`
+    : args.viewportWidth
+      ? `${args.viewportWidth}px wide`
+      : args.viewportHeight
+        ? `${args.viewportHeight}px tall`
+        : "";
+  const orientation = args.orientation ? ` ${args.orientation}` : "";
+  return `${preset}${size ? ` ${size}` : ""}${orientation}`.trim();
+}
+
 function getHumanSummary(args?: ChromiumWorkspaceArgs): string {
   if (!args?.action) return "Browser action";
 
@@ -148,6 +169,10 @@ function getHumanSummary(args?: ChromiumWorkspaceArgs): string {
       return args.expression
         ? `Running: ${args.expression.slice(0, 30)}${args.expression.length > 30 ? "..." : ""}`
         : "Running JS";
+    case "setViewport":
+      return `Setting ${getViewportSummary(args)}`;
+    case "resetViewport":
+      return "Resetting to desktop viewport";
     case "close":
       return "Closing session";
     default:
@@ -179,6 +204,10 @@ function getActionSummary(args?: ChromiumWorkspaceArgs): string {
       return args.expression
         ? `${args.expression.slice(0, 40)}${args.expression.length > 40 ? "..." : ""}`
         : "Running JS...";
+    case "setViewport":
+      return getViewportSummary(args);
+    case "resetViewport":
+      return "Default desktop viewport";
     case "close":
       return "Closing session";
     default:

--- a/components/browser-session/browser-action-helpers.ts
+++ b/components/browser-session/browser-action-helpers.ts
@@ -13,6 +13,7 @@ import {
   X,
   Play,
   ArrowRight,
+  ArrowClockwise,
 } from "@phosphor-icons/react";
 
 // ─── Action icon mapping ──────────────────────────────────────────────────────
@@ -26,6 +27,8 @@ const ACTION_ICONS: Record<string, typeof Globe> = {
   extract: Eye,
   replay: Play,
   evaluate: Code,
+  setViewport: Eye,
+  resetViewport: ArrowClockwise,
   close: X,
 };
 
@@ -42,6 +45,8 @@ export function getActionLabel(action: string): string {
     snapshot: "Snapshot",
     extract: "Extract",
     evaluate: "Evaluate",
+    setViewport: "Set Viewport",
+    resetViewport: "Reset Viewport",
     close: "Close",
     replay: "Replay",
   };

--- a/components/browser-session/browser-session-viewer.tsx
+++ b/components/browser-session/browser-session-viewer.tsx
@@ -34,7 +34,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { useScreencastRecorder } from "./use-screencast-recorder";
-import { useBrowserInteraction } from "./use-browser-interaction";
+import { useBrowserInteraction, type BrowserViewportSize } from "./use-browser-interaction";
 import { useActionIndicators, type ActionSSEData } from "./use-action-indicators";
 import { ActionIndicators } from "./action-indicators";
 
@@ -64,6 +64,29 @@ interface SessionHistory {
   actions: ActionRecord[];
 }
 
+interface ScreencastFrameMetadata {
+  deviceWidth?: number;
+  deviceHeight?: number;
+}
+
+interface ScreencastFrameEvent {
+  data?: string;
+  ts?: number;
+  metadata?: ScreencastFrameMetadata;
+}
+
+function viewportSizeFromMetadata(
+  metadata?: ScreencastFrameMetadata
+): BrowserViewportSize | null {
+  if (!metadata) return null;
+  const width = Math.round(Number(metadata.deviceWidth));
+  const height = Math.round(Number(metadata.deviceHeight));
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
 // ─── Action helpers ───────────────────────────────────────────────────────────
 
 const ACTION_ICONS: Record<string, typeof Globe> = {
@@ -75,6 +98,8 @@ const ACTION_ICONS: Record<string, typeof Globe> = {
   extract: Eye,
   replay: Play,
   evaluate: Code,
+  setViewport: Eye,
+  resetViewport: ArrowClockwise,
   close: X,
 };
 
@@ -91,6 +116,8 @@ function getActionLabel(action: string): string {
     snapshot: "Snapshot",
     extract: "Extract",
     evaluate: "Evaluate",
+    setViewport: "Set Viewport",
+    resetViewport: "Reset Viewport",
     close: "Close",
     replay: "Replay",
   };
@@ -126,6 +153,7 @@ export const BrowserSessionViewer: FC<{ sessionId: string }> = ({ sessionId }) =
   // activeSessionId drives SSE + history polling.
   // Starts as the prop sessionId, switches when replay starts.
   const [activeSessionId, setActiveSessionId] = useState(sessionId);
+  const [viewportSize, setViewportSize] = useState<BrowserViewportSize | null>(null);
 
   // Store the original session history for the replay button
   const originalHistoryRef = useRef<SessionHistory | null>(null);
@@ -150,6 +178,7 @@ export const BrowserSessionViewer: FC<{ sessionId: string }> = ({ sessionId }) =
   } = useBrowserInteraction({
     sessionId: activeSessionId,
     imgRef,
+    viewportSize,
     enabled: isInteractive,
     containerRef: interactionContainerRef,
   });
@@ -160,6 +189,7 @@ export const BrowserSessionViewer: FC<{ sessionId: string }> = ({ sessionId }) =
     sessionId: activeSessionId,
     imgRef,
     containerRef: interactionContainerRef,
+    viewportSize,
     enabled: showIndicators,
   });
 
@@ -231,6 +261,7 @@ export const BrowserSessionViewer: FC<{ sessionId: string }> = ({ sessionId }) =
     hasFrameRef.current = false;
     setHasFrame(false);
     setIsConnected(false);
+    setViewportSize(null);
 
     const connect = () => {
       const es = new EventSource(`/api/browser/${activeSessionId}/stream`);
@@ -242,7 +273,16 @@ export const BrowserSessionViewer: FC<{ sessionId: string }> = ({ sessionId }) =
 
       es.onmessage = (event) => {
         try {
-          const { data } = JSON.parse(event.data) as { data: string; ts: number };
+          const { data, metadata } = JSON.parse(event.data) as ScreencastFrameEvent;
+          const nextViewportSize = viewportSizeFromMetadata(metadata);
+          if (mounted && nextViewportSize) {
+            setViewportSize((prev) => {
+              if (prev?.width === nextViewportSize.width && prev.height === nextViewportSize.height) {
+                return prev;
+              }
+              return nextViewportSize;
+            });
+          }
           if (data) {
             const src = `data:image/jpeg;base64,${data}`;
             if (imgRef.current) {

--- a/components/browser-session/use-action-indicators.ts
+++ b/components/browser-session/use-action-indicators.ts
@@ -9,6 +9,7 @@
  */
 
 import { useCallback, useRef, useState, useEffect, type RefObject } from "react";
+import type { BrowserViewportSize } from "./use-browser-interaction";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,7 @@ interface UseActionIndicatorsOptions {
   sessionId: string;
   imgRef: RefObject<HTMLImageElement | null>;
   containerRef: RefObject<HTMLElement | null>;
+  viewportSize?: BrowserViewportSize | null;
   enabled: boolean;
 }
 
@@ -70,26 +72,30 @@ function viewportToDisplay(
   viewportX: number,
   viewportY: number,
   img: HTMLImageElement,
-  container: HTMLElement | null
+  container: HTMLElement | null,
+  viewportSize?: BrowserViewportSize | null
 ): { x: number; y: number } | null {
+  const viewport = viewportSize?.width && viewportSize.height
+    ? viewportSize
+    : img.naturalWidth > 0 && img.naturalHeight > 0
+      ? { width: img.naturalWidth, height: img.naturalHeight }
+      : null;
+
+  if (!viewport) return null;
+
   const rect = img.getBoundingClientRect();
   const containerRect = container?.getBoundingClientRect();
-  // Viewport is always 1280x720 as set in session-manager.ts.
-  // Using naturalWidth/naturalHeight would be wrong on HiDPI/Retina
-  // displays where the screencast frame is rendered at 2x pixel ratio.
-  const VIEWPORT_W = 1280;
-  const VIEWPORT_H = 720;
 
-  const scale = Math.min(rect.width / VIEWPORT_W, rect.height / VIEWPORT_H);
-  const renderedW = VIEWPORT_W * scale;
-  const renderedH = VIEWPORT_H * scale;
+  const scale = Math.min(rect.width / viewport.width, rect.height / viewport.height);
+  const renderedW = viewport.width * scale;
+  const renderedH = viewport.height * scale;
   const offsetX = (rect.width - renderedW) / 2;
   const offsetY = (rect.height - renderedH) / 2;
   const baseX = containerRect ? rect.left - containerRect.left : 0;
   const baseY = containerRect ? rect.top - containerRect.top : 0;
 
-  const displayX = baseX + (viewportX / VIEWPORT_W) * renderedW + offsetX;
-  const displayY = baseY + (viewportY / VIEWPORT_H) * renderedH + offsetY;
+  const displayX = baseX + (viewportX / viewport.width) * renderedW + offsetX;
+  const displayY = baseY + (viewportY / viewport.height) * renderedH + offsetY;
 
   return { x: displayX, y: displayY };
 }
@@ -101,6 +107,7 @@ let indicatorCounter = 0;
 export function useActionIndicators({
   imgRef,
   containerRef,
+  viewportSize,
   enabled,
 }: UseActionIndicatorsOptions): UseActionIndicatorsReturn {
   const [indicators, setIndicators] = useState<ActionIndicator[]>([]);
@@ -144,7 +151,7 @@ export function useActionIndicators({
       const inputY = data.input?.y;
 
       if (typeof inputX === "number" && typeof inputY === "number") {
-        const display = viewportToDisplay(inputX, inputY, img, containerRef.current);
+        const display = viewportToDisplay(inputX, inputY, img, containerRef.current, viewportSize);
         if (display) {
           x = display.x;
           y = display.y;
@@ -188,7 +195,7 @@ export function useActionIndicators({
 
       timersRef.current.set(id, timer);
     },
-    [containerRef, imgRef]
+    [containerRef, imgRef, viewportSize]
   );
 
   return { indicators, addAction, clearIndicators };

--- a/components/browser-session/use-browser-interaction.ts
+++ b/components/browser-session/use-browser-interaction.ts
@@ -8,7 +8,8 @@
  * interact API endpoint. This lets users directly control the browser the agent is using.
  *
  * Coordinate mapping: the screencast is rendered with object-contain at arbitrary
- * display size, but the Playwright session always runs at a fixed 1280x720 viewport.
+ * display size. We map against the active browser viewport reported by the
+ * screencast metadata so responsive/mobile/tablet viewport changes remain accurate.
  */
 
 import { useCallback, useEffect, useState, type RefObject } from "react";
@@ -27,9 +28,16 @@ interface InteractPayload {
   url?: string;
 }
 
+export interface BrowserViewportSize {
+  width: number;
+  height: number;
+}
+
 interface UseBrowserInteractionOptions {
   sessionId: string;
   imgRef: RefObject<HTMLImageElement | null>;
+  /** Active browser viewport in CSS pixels, sourced from screencast metadata. */
+  viewportSize?: BrowserViewportSize | null;
   /** Whether interactive mode is currently active */
   enabled: boolean;
   /** Container element ref for attaching non-passive wheel listener */
@@ -45,32 +53,50 @@ interface UseBrowserInteractionReturn {
   navigate: (url: string) => Promise<void>;
 }
 
-const VIEWPORT_W = 1280;
-const VIEWPORT_H = 720;
+function getViewportSize(
+  img: HTMLImageElement,
+  viewportSize?: BrowserViewportSize | null
+): BrowserViewportSize | null {
+  if (viewportSize?.width && viewportSize.height) return viewportSize;
+  if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+    return { width: img.naturalWidth, height: img.naturalHeight };
+  }
+  return null;
+}
 
-function getRenderedFrameMetrics(img: HTMLImageElement) {
+function getRenderedFrameMetrics(
+  img: HTMLImageElement,
+  viewportSize?: BrowserViewportSize | null
+) {
+  const viewport = getViewportSize(img, viewportSize);
+  if (!viewport) return null;
+
   const rect = img.getBoundingClientRect();
-  const scale = Math.min(rect.width / VIEWPORT_W, rect.height / VIEWPORT_H);
-  const renderedW = VIEWPORT_W * scale;
-  const renderedH = VIEWPORT_H * scale;
+  const scale = Math.min(rect.width / viewport.width, rect.height / viewport.height);
+  const renderedW = viewport.width * scale;
+  const renderedH = viewport.height * scale;
   const offsetX = (rect.width - renderedW) / 2;
   const offsetY = (rect.height - renderedH) / 2;
 
-  return { rect, renderedW, renderedH, offsetX, offsetY };
+  return { rect, viewport, renderedW, renderedH, offsetX, offsetY };
 }
 
 /**
  * Map a pointer position on the rendered <img> element to browser viewport coordinates.
  *
- * The screencast can be emitted at HiDPI pixel sizes, so we map against the known
- * Playwright viewport instead of img.naturalWidth/img.naturalHeight.
+ * The screencast can be emitted at arbitrary responsive sizes, so we map against
+ * active viewport metadata when available and fall back to the image's natural size.
  */
 function mapPointToViewport(
   clientX: number,
   clientY: number,
-  img: HTMLImageElement
+  img: HTMLImageElement,
+  viewportSize?: BrowserViewportSize | null
 ): { x: number; y: number } | null {
-  const { rect, renderedW, renderedH, offsetX, offsetY } = getRenderedFrameMetrics(img);
+  const metrics = getRenderedFrameMetrics(img, viewportSize);
+  if (!metrics) return null;
+
+  const { rect, viewport, renderedW, renderedH, offsetX, offsetY } = metrics;
   const mouseX = clientX - rect.left;
   const mouseY = clientY - rect.top;
 
@@ -83,8 +109,8 @@ function mapPointToViewport(
     return null;
   }
 
-  const viewportX = ((mouseX - offsetX) / renderedW) * VIEWPORT_W;
-  const viewportY = ((mouseY - offsetY) / renderedH) * VIEWPORT_H;
+  const viewportX = ((mouseX - offsetX) / renderedW) * viewport.width;
+  const viewportY = ((mouseY - offsetY) / renderedH) * viewport.height;
 
   return { x: Math.round(viewportX), y: Math.round(viewportY) };
 }
@@ -92,6 +118,7 @@ function mapPointToViewport(
 export function useBrowserInteraction({
   sessionId,
   imgRef,
+  viewportSize,
   enabled,
   containerRef,
 }: UseBrowserInteractionOptions): UseBrowserInteractionReturn {
@@ -118,7 +145,7 @@ export function useBrowserInteraction({
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!enabled || !imgRef.current) return;
 
-    const pos = mapPointToViewport(e.clientX, e.clientY, imgRef.current);
+    const pos = mapPointToViewport(e.clientX, e.clientY, imgRef.current, viewportSize);
     if (!pos) return;
 
     e.preventDefault();
@@ -131,7 +158,7 @@ export function useBrowserInteraction({
       button,
       clickCount: e.detail || 1,
     });
-  }, [enabled, imgRef, sendInteraction]);
+  }, [enabled, imgRef, sendInteraction, viewportSize]);
 
 
   // Non-passive wheel listener attached via useEffect so preventDefault() works.
@@ -143,7 +170,7 @@ export function useBrowserInteraction({
       const img = imgRef.current;
       if (!img) return;
 
-      const pos = mapPointToViewport(e.clientX, e.clientY, img);
+      const pos = mapPointToViewport(e.clientX, e.clientY, img, viewportSize);
       if (!pos) return;
 
       e.preventDefault();
@@ -158,7 +185,7 @@ export function useBrowserInteraction({
 
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
-  }, [enabled, containerRef, imgRef, sendInteraction]);
+  }, [enabled, containerRef, imgRef, sendInteraction, viewportSize]);
 
   const navigate = useCallback(async (url: string) => {
     if (!url) return;

--- a/lib/ai/tool-registry/register-collaboration-tools.ts
+++ b/lib/ai/tool-registry/register-collaboration-tools.ts
@@ -647,9 +647,14 @@ ${getSceneGuideSummary()}
         "evaluate",
         "javascript",
         "automation",
+        "viewport",
+        "responsive",
+        "mobile",
+        "tablet",
+        "orientation",
       ],
       shortDescription:
-        "Embedded Chromium browser for web automation — navigate, click, type, extract, evaluate",
+        "Embedded Chromium browser for web automation — navigate, click, type, extract, evaluate, and test responsive viewports",
       fullInstructions: `## Chromium Workspace
 
 Isolated, embedded browser for web automation. One tool, multiple actions.
@@ -662,11 +667,15 @@ Isolated, embedded browser for web automation. One tool, multiple actions.
 - \`snapshot\`: Get accessibility tree of the page (structured, token-efficient observation).
 - \`extract\`: Get text content from an element. \`{ action: "extract", selector: ".content" }\`
 - \`evaluate\`: Run JavaScript in page context. \`{ action: "evaluate", expression: "document.title" }\`
+- \`setViewport\`: Set responsive viewport. \`{ action: "setViewport", viewportPreset: "mobile", orientation: "portrait" }\`
+- \`resetViewport\`: Reset to default desktop viewport. \`{ action: "resetViewport" }\`
 - \`close\`: End session, return execution history summary.
 
-**Workflow:** open → (navigate/click/type/snapshot/extract/evaluate)* → close
+**Responsive viewport controls:** pass \`viewportPreset\`, \`viewportWidth\`, \`viewportHeight\`, \`orientation\`, or \`resetViewport\` directly on \`open\`, \`navigate\`, \`snapshot\`, \`extract\`, \`evaluate\`, \`click\`, or \`type\`; the viewport is applied before the action. Common presets include \`mobile\`, \`iphone-se\`, \`iphone-14\`, \`pixel-7\`, \`tablet\`, \`ipad\`, \`ipad-pro\`, \`desktop\`, and \`desktop-wide\`.
+
+**Workflow:** open → (setViewport/navigate/click/type/snapshot/extract/evaluate)* → close
 **Isolation:** Each agent gets its own sandboxed browser context.
-**Observation:** Prefer \`snapshot\` over screenshots — structured data, no vision model needed.`,
+**Observation:** Prefer \`snapshot\` over screenshots — structured data, no vision model needed. Tool results include current viewport metadata.`,
       loading: { deferLoading: true },
       requiresSession: true,
     } satisfies ToolMetadata,

--- a/lib/ai/tools/chromium-workspace-tool.ts
+++ b/lib/ai/tools/chromium-workspace-tool.ts
@@ -2,12 +2,15 @@
  * Chromium Workspace Tool
  *
  * Single multi-action tool for embedded browser automation.
- * Actions: open, navigate, click, type, snapshot, extract, evaluate, close
+ * Actions: open, navigate, click, type, snapshot, extract, evaluate,
+ * setViewport, resetViewport, close, replay
  *
- * Each invocation is scoped to the calling agent's sessionId via the
- * session manager — parallel agents get isolated BrowserContexts.
+ * Each invocation is scoped to the calling agent's sessionId via the session
+ * manager. Standalone browser mode uses isolated BrowserContexts; user-chrome
+ * mode intentionally shares one persistent browser profile and isolates sessions
+ * at the page/tab level.
  *
- * Every action is recorded with full input/output/domSnapshot for
+ * Every action is recorded with full input/output/viewport/domSnapshot for
  * deterministic replay and audit trails.
  *
  * Observation model: accessibility tree snapshots (token-efficient,
@@ -18,6 +21,8 @@ import { tool, jsonSchema } from "ai";
 import {
   getOrCreateSession,
   closeSession,
+  setBrowserSessionViewport,
+  getBrowserSessionViewport,
   type BrowserSession,
 } from "@/lib/browser/session-manager";
 import {
@@ -27,10 +32,17 @@ import {
   outputsMatch,
   type ReplayResult,
 } from "@/lib/browser/action-history";
+import {
+  DEFAULT_BROWSER_VIEWPORT,
+  hasBrowserViewportInput,
+  listBrowserViewportPresets,
+  type BrowserViewport,
+  type BrowserViewportInput,
+} from "@/lib/browser/viewport";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type ActionType =
+export type ActionType =
   | "open"
   | "navigate"
   | "click"
@@ -38,10 +50,12 @@ type ActionType =
   | "snapshot"
   | "extract"
   | "evaluate"
+  | "setViewport"
+  | "resetViewport"
   | "close"
   | "replay";
 
-interface ChromiumWorkspaceInput {
+export interface ChromiumWorkspaceInput extends BrowserViewportInput {
   action: ActionType;
   /** URL to navigate to (open, navigate) */
   url?: string;
@@ -77,6 +91,7 @@ interface ActionResult {
   data: unknown;
   pageUrl?: string;
   pageTitle?: string;
+  viewport?: BrowserViewport;
   /** Accessibility snapshot captured after action (for history) */
   domSnapshot?: string;
 }
@@ -93,6 +108,7 @@ export function createChromiumWorkspaceTool(options: {
   agentId?: string;
 }) {
   const { sessionId, agentId } = options;
+  const viewportPresetNames = listBrowserViewportPresets();
 
   return tool({
     description: `Embedded Chromium workspace for browser automation. Single tool, multiple actions.
@@ -105,12 +121,21 @@ export function createChromiumWorkspaceTool(options: {
 - \`snapshot\`: Get an accessibility tree snapshot of the current page (token-efficient observation).
 - \`extract\`: Extract text content from an element. \`{ action: "extract", selector: ".content" }\`
 - \`evaluate\`: Execute JavaScript in the page context. \`{ action: "evaluate", expression: "document.title" }\`
+- \`setViewport\`: Set the active browser viewport. \`{ action: "setViewport", viewportPreset: "mobile", orientation: "portrait" }\`
+- \`resetViewport\`: Reset to the default desktop viewport. \`{ action: "resetViewport" }\`
 - \`close\`: Close the browser session and return full execution history.
 - \`replay\`: Re-execute a recorded action history with optional output verification.
 
-**Isolation:** Each agent session gets its own sandboxed browser context (cookies, storage, service workers are isolated).
+**Responsive viewport controls:** Pass viewport options directly on \`open\`, \`navigate\`, \`snapshot\`, \`extract\`, \`evaluate\`, \`click\`, or \`type\` and they are applied before the action runs. Use \`viewportWidth\` + \`viewportHeight\` for custom CSS pixel dimensions, \`orientation\` for \`portrait\`/\`landscape\`, \`viewportPreset\` for common devices (${viewportPresetNames.join(", ")}), or \`resetViewport: true\` to restore desktop.
+
+**Examples:**
+- Mobile portrait open: \`{ action: "open", url: "https://example.com", viewportPreset: "mobile", orientation: "portrait" }\`
+- Tablet landscape inspect: \`{ action: "snapshot", viewportPreset: "tablet", orientation: "landscape" }\`
+- Custom size: \`{ action: "setViewport", viewportWidth: 1024, viewportHeight: 768 }\`
+
+**Isolation:** Standalone browser mode gives each agent session its own sandboxed browser context (cookies, storage, service workers are isolated). User-chrome mode shares the persistent browser profile and isolates sessions at the page/tab level.
 **Observation:** Use \`snapshot\` to observe page state — returns structured accessibility data, not screenshots.
-**History:** Every action is recorded with input, output, and DOM snapshot for replay.
+**History:** Every action is recorded with input, output, viewport, and DOM snapshot for replay.
 **Replay:** Use \`close\` to get a history, then \`replay\` to deterministically re-execute it.`,
 
     inputSchema: jsonSchema<ChromiumWorkspaceInput>({
@@ -121,7 +146,7 @@ export function createChromiumWorkspaceTool(options: {
           type: "string",
           enum: [
             "open", "navigate", "click", "type",
-            "snapshot", "extract", "evaluate", "close", "replay",
+            "snapshot", "extract", "evaluate", "setViewport", "resetViewport", "close", "replay",
           ],
           description: "The browser action to perform",
         },
@@ -144,6 +169,28 @@ export function createChromiumWorkspaceTool(options: {
         timeout: {
           type: "number",
           description: "Timeout in milliseconds (default: 30000)",
+        },
+        viewportPreset: {
+          type: "string",
+          enum: viewportPresetNames,
+          description: "Common responsive viewport preset. Can be used with open/navigate/snapshot/extract/evaluate/click/type or action=setViewport. Available presets include mobile, tablet, ipad, ipad-pro, iphone-se, iphone-14, pixel-7, desktop, desktop-wide.",
+        },
+        viewportWidth: {
+          type: "number",
+          description: "Custom viewport width in CSS pixels (100-10000). Can be combined with viewportHeight and orientation.",
+        },
+        viewportHeight: {
+          type: "number",
+          description: "Custom viewport height in CSS pixels (100-10000). Can be combined with viewportWidth and orientation.",
+        },
+        orientation: {
+          type: "string",
+          enum: ["portrait", "landscape"],
+          description: "Viewport orientation. If the selected/custom dimensions are in the opposite orientation, width and height are swapped before the action runs.",
+        },
+        resetViewport: {
+          type: "boolean",
+          description: "Reset the current session to the default desktop viewport before running this action. Equivalent to action=resetViewport when used alone.",
         },
         history: {
           type: "string",
@@ -173,6 +220,7 @@ export function createChromiumWorkspaceTool(options: {
           success: true,
           durationMs,
           output: result.data,
+          viewport: result.viewport,
           pageUrl: result.pageUrl,
           pageTitle: result.pageTitle,
           domSnapshot: result.domSnapshot,
@@ -186,6 +234,7 @@ export function createChromiumWorkspaceTool(options: {
           data: result.data,
           pageUrl: result.pageUrl,
           pageTitle: result.pageTitle,
+          viewport: result.viewport,
         };
       } catch (err) {
         const durationMs = Date.now() - startTime;
@@ -194,6 +243,7 @@ export function createChromiumWorkspaceTool(options: {
         recordAction(sessionId, action, sanitizeInput(input), {
           success: false,
           durationMs,
+          viewport: getBrowserSessionViewport(sessionId) ?? undefined,
           error: errorMsg,
           source: "agent",
         });
@@ -234,13 +284,19 @@ export async function executeAction(
       result = await handleType(sessionId, input, timeout);
       break;
     case "snapshot":
-      result = await handleSnapshot(sessionId);
+      result = await handleSnapshot(sessionId, input);
       break;
     case "extract":
       result = await handleExtract(sessionId, input, timeout);
       break;
     case "evaluate":
       result = await handleEvaluate(sessionId, input, timeout);
+      break;
+    case "setViewport":
+      result = await handleSetViewport(sessionId, input);
+      break;
+    case "resetViewport":
+      result = await handleResetViewport(sessionId);
       break;
     case "close":
       result = await handleClose(sessionId);
@@ -271,7 +327,7 @@ async function handleOpen(
   if (!input.url) throw new Error("'url' is required for the 'open' action");
 
   initHistory(sessionId, agentId);
-  const session = await getOrCreateSession(sessionId);
+  const session = await getOrCreateSession(sessionId, input);
 
   await session.page.goto(input.url, {
     waitUntil: "domcontentloaded",
@@ -282,6 +338,7 @@ async function handleOpen(
     data: `Browser session opened. Navigated to: ${input.url}`,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
   };
 }
 
@@ -292,7 +349,7 @@ async function handleNavigate(
 ): Promise<ActionResult> {
   if (!input.url) throw new Error("'url' is required for the 'navigate' action");
 
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   await session.page.goto(input.url, {
     waitUntil: "domcontentloaded",
@@ -303,6 +360,7 @@ async function handleNavigate(
     data: `Navigated to: ${input.url}`,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
   };
 }
 
@@ -313,7 +371,7 @@ async function handleClick(
 ): Promise<ActionResult> {
   if (!input.selector) throw new Error("'selector' is required for the 'click' action");
 
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   await session.page.waitForSelector(input.selector, { timeout });
   await session.page.click(input.selector);
@@ -325,6 +383,7 @@ async function handleClick(
     data: `Clicked element: ${input.selector}`,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
   };
 }
 
@@ -336,7 +395,7 @@ async function handleType(
   if (!input.selector) throw new Error("'selector' is required for the 'type' action");
   if (!input.text) throw new Error("'text' is required for the 'type' action");
 
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   await session.page.waitForSelector(input.selector, { timeout });
   await session.page.fill(input.selector, input.text);
@@ -345,13 +404,15 @@ async function handleType(
     data: `Typed "${input.text.slice(0, 50)}${input.text.length > 50 ? "..." : ""}" into ${input.selector}`,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
   };
 }
 
 async function handleSnapshot(
-  sessionId: string
+  sessionId: string,
+  input: ChromiumWorkspaceInput
 ): Promise<ActionResult> {
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   const snapshot = await session.page.locator("body").ariaSnapshot();
   const pageUrl = session.page.url();
@@ -361,10 +422,12 @@ async function handleSnapshot(
     data: {
       url: pageUrl,
       title: pageTitle,
+      viewport: session.viewport,
       accessibilityTree: snapshot,
     },
     pageUrl,
     pageTitle,
+    viewport: session.viewport,
     // snapshot action itself IS the domSnapshot
     domSnapshot: snapshot,
   };
@@ -377,7 +440,7 @@ async function handleExtract(
 ): Promise<ActionResult> {
   if (!input.selector) throw new Error("'selector' is required for the 'extract' action");
 
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   await session.page.waitForSelector(input.selector, { timeout });
   const textContent = await session.page.$eval(input.selector, (el) => el.textContent ?? "");
@@ -390,6 +453,7 @@ async function handleExtract(
     data: truncated,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
   };
 }
 
@@ -400,7 +464,7 @@ async function handleEvaluate(
 ): Promise<ActionResult> {
   if (!input.expression) throw new Error("'expression' is required for the 'evaluate' action");
 
-  const session = await getSessionOrThrow(sessionId);
+  const session = await getSessionOrThrow(sessionId, input);
 
   // Apply a timeout to prevent indefinite blocking from long-running
   // expressions (e.g., those with setTimeout delays for audio playback).
@@ -428,18 +492,60 @@ async function handleEvaluate(
     data: serialized?.slice(0, 5000) ?? null,
     pageUrl: session.page.url(),
     pageTitle: await session.page.title(),
+    viewport: session.viewport,
+  };
+}
+
+async function handleSetViewport(
+  sessionId: string,
+  input: ChromiumWorkspaceInput
+): Promise<ActionResult> {
+  if (!hasBrowserViewportInput(input)) {
+    throw new Error("setViewport requires viewportPreset, viewportWidth/viewportHeight, orientation, or resetViewport");
+  }
+
+  const viewport = await setBrowserSessionViewport(sessionId, input);
+  const session = await getSessionOrThrow(sessionId);
+
+  return {
+    data: {
+      message: `Viewport set to ${viewport.width}×${viewport.height} (${viewport.orientation})`,
+      viewport,
+    },
+    pageUrl: session.page.url(),
+    pageTitle: await session.page.title(),
+    viewport,
+  };
+}
+
+async function handleResetViewport(
+  sessionId: string
+): Promise<ActionResult> {
+  const viewport = await setBrowserSessionViewport(sessionId, { resetViewport: true });
+  const session = await getSessionOrThrow(sessionId);
+
+  return {
+    data: {
+      message: `Viewport reset to default desktop ${viewport.width}×${viewport.height}`,
+      viewport,
+    },
+    pageUrl: session.page.url(),
+    pageTitle: await session.page.title(),
+    viewport,
   };
 }
 
 async function handleClose(
   sessionId: string
 ): Promise<ActionResult> {
+  const viewport = getBrowserSessionViewport(sessionId) ?? DEFAULT_BROWSER_VIEWPORT;
   const history = finalizeHistory(sessionId);
   await closeSession(sessionId);
 
   return {
     data: {
       message: "Browser session closed",
+      viewport,
       history: history
         ? {
             sessionId: history.sessionId,
@@ -454,6 +560,7 @@ async function handleClose(
           }
         : null,
     },
+    viewport,
   };
 }
 
@@ -501,12 +608,14 @@ async function handleReplay(
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
-        // Build the input for this action
-        const stepInput: ChromiumWorkspaceInput = {
+        // Build the input for this action. Keep the replay plan action authoritative.
+        const sanitizedStepInput = { ...step.input };
+        delete sanitizedStepInput.action;
+        const stepInput = {
+          ...sanitizedStepInput,
           action: step.action as ActionType,
-          ...step.input,
           timeout,
-        };
+        } as ChromiumWorkspaceInput;
 
         const result = await executeAction(sessionId, stepInput, timeout, agentId);
         replayOutput = result.data;
@@ -551,6 +660,8 @@ async function handleReplay(
     ? results.filter((r) => r.outputMatches).length
     : null;
 
+  const viewport = getBrowserSessionViewport(sessionId) ?? DEFAULT_BROWSER_VIEWPORT;
+
   return {
     data: {
       message: aborted
@@ -561,8 +672,10 @@ async function handleReplay(
       failedActions: failCount,
       outputMatchCount: verifyCount,
       aborted,
+      viewport,
       results,
     },
+    viewport,
   };
 }
 
@@ -572,8 +685,11 @@ function sleep(ms: number): Promise<void> {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async function getSessionOrThrow(sessionId: string): Promise<BrowserSession> {
-  const session = await getOrCreateSession(sessionId);
+async function getSessionOrThrow(
+  sessionId: string,
+  viewportInput?: BrowserViewportInput
+): Promise<BrowserSession> {
+  const session = await getOrCreateSession(sessionId, viewportInput);
   if (!session) {
     throw new Error(
       `No active browser session for this agent. Use action "open" with a URL to start one.`
@@ -603,5 +719,10 @@ function sanitizeInput(input: ChromiumWorkspaceInput): Record<string, unknown> {
   if (input.text) params.text = input.text.slice(0, 200);
   if (input.expression) params.expression = input.expression.slice(0, 200);
   if (input.timeout) params.timeout = input.timeout;
+  if (input.viewportPreset) params.viewportPreset = input.viewportPreset;
+  if (input.viewportWidth != null) params.viewportWidth = input.viewportWidth;
+  if (input.viewportHeight != null) params.viewportHeight = input.viewportHeight;
+  if (input.orientation) params.orientation = input.orientation;
+  if (input.resetViewport === true) params.resetViewport = true;
   return params;
 }

--- a/lib/browser/action-history.ts
+++ b/lib/browser/action-history.ts
@@ -5,7 +5,7 @@
  *  1. Audit trail — see exactly what the agent did
  *  2. Deterministic replay — re-run a recorded session and verify outputs
  *
- * Each action record captures: action, input, output, domSnapshot,
+ * Each action record captures: action, input, output, viewport, domSnapshot,
  * timestamp, sessionId, and agentId. History is in-memory during the
  * session, returned as a structured object on close (stored alongside
  * tool call logs in message content parts).
@@ -13,6 +13,8 @@
  * Replay re-executes the action sequence with same inputs and optionally
  * verifies that outputs match the original recording.
  */
+
+import type { BrowserViewport } from "@/lib/browser/viewport";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,6 +33,9 @@ export interface ActionRecord {
 
   /** The structured output returned by the action */
   output: unknown;
+
+  /** Resolved browser viewport active when the action completed */
+  viewport?: BrowserViewport;
 
   /** Whether the action succeeded */
   success: boolean;
@@ -188,6 +193,7 @@ export function recordAction(
     success: boolean;
     durationMs: number;
     output?: unknown;
+    viewport?: BrowserViewport;
     pageUrl?: string;
     pageTitle?: string;
     domSnapshot?: string;
@@ -205,6 +211,7 @@ export function recordAction(
     action,
     input,
     output: result.output ?? null,
+    viewport: result.viewport,
     success: result.success,
     durationMs: result.durationMs,
     pageUrl: result.pageUrl,

--- a/lib/browser/session-manager.ts
+++ b/lib/browser/session-manager.ts
@@ -14,12 +14,21 @@
  * Singleton: stored on globalThis to survive Next.js hot reloads.
  */
 
-import type { Browser, BrowserContext, Page } from "playwright-core";
+import type { Browser, BrowserContext, BrowserContextOptions, Page } from "playwright-core";
 import { join } from "path";
 import { homedir, platform, tmpdir } from "os";
 import { cpSync, mkdirSync, rmSync, existsSync } from "fs";
 import { startScreencast, stopScreencast } from "./screencast";
 import { cleanupInputSession, cleanupAllInputSessions } from "./input-dispatcher";
+import {
+  applyBrowserViewportToPage,
+  browserViewportToContextOptions,
+  DEFAULT_BROWSER_VIEWPORT,
+  hasBrowserViewportInput,
+  resolveBrowserViewport,
+  type BrowserViewport,
+  type BrowserViewportInput,
+} from "./viewport";
 
 // ─── Timeout helpers ──────────────────────────────────────────────────────────
 
@@ -60,6 +69,7 @@ export interface BrowserSession {
   sessionId: string;
   context: BrowserContext;
   page: Page;
+  viewport: BrowserViewport;
   createdAt: number;
   lastAccessedAt: number;
 }
@@ -143,6 +153,28 @@ function getBrowserSettings(): { mode: "standalone" | "user-chrome"; profilePath
   } catch {
     return { mode: "standalone", profilePath: "" };
   }
+}
+
+function createStandaloneContextOptions(
+  viewport: BrowserViewport = DEFAULT_BROWSER_VIEWPORT
+): BrowserContextOptions {
+  return {
+    ...browserViewportToContextOptions(viewport),
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Selene/1.0",
+    javaScriptEnabled: true,
+    ignoreHTTPSErrors: true,
+  };
+}
+
+async function applyViewportToSession(
+  session: BrowserSession,
+  input: BrowserViewportInput
+): Promise<BrowserViewport> {
+  const viewport = resolveBrowserViewport(input, session.viewport);
+  await applyBrowserViewportToPage(session.page, viewport);
+  session.viewport = viewport;
+  return viewport;
 }
 
 // ─── Browser lifecycle ────────────────────────────────────────────────────────
@@ -412,7 +444,7 @@ async function launchUserChrome(
       args: [
         "--disable-blink-features=AutomationControlled",
       ],
-      viewport: { width: 1280, height: 720 },
+      ...browserViewportToContextOptions(DEFAULT_BROWSER_VIEWPORT),
       // No custom UA — use Chrome's real one for anti-detection
       ignoreHTTPSErrors: true,
     });
@@ -490,9 +522,15 @@ function cleanupTempProfile(state: ChromiumManagerState): void {
  * In user-chrome mode: sessions share the persistent context (same cookies,
  * extensions, fingerprint) but each gets a separate page/tab.
  */
-export async function getOrCreateSession(sessionId: string): Promise<BrowserSession> {
+export async function getOrCreateSession(
+  sessionId: string,
+  viewportInput?: BrowserViewportInput
+): Promise<BrowserSession> {
   const state = getState();
   const existing = state.sessions.get(sessionId);
+  const requestedViewport = hasBrowserViewportInput(viewportInput)
+    ? resolveBrowserViewport(viewportInput, DEFAULT_BROWSER_VIEWPORT)
+    : DEFAULT_BROWSER_VIEWPORT;
 
   if (existing) {
     // Verify the page is still alive — pages can crash silently during heavy
@@ -521,6 +559,9 @@ export async function getOrCreateSession(sessionId: string): Promise<BrowserSess
       }
     } else {
       existing.lastAccessedAt = Date.now();
+      if (hasBrowserViewportInput(viewportInput)) {
+        await applyViewportToSession(existing, viewportInput!);
+      }
       return existing;
     }
   }
@@ -529,25 +570,21 @@ export async function getOrCreateSession(sessionId: string): Promise<BrowserSess
 
   let context: BrowserContext;
   let page: Page;
+  let viewport = requestedViewport;
 
   try {
     if (state.browserMode === "user-chrome" && state.persistentContext) {
       // User-chrome mode: reuse the persistent context, create a new page/tab
       context = state.persistentContext;
       page = await context.newPage();
+      await applyBrowserViewportToPage(page, viewport);
     } else {
       // Standalone mode: create an isolated context per session
       if (!state.browser) {
         throw new Error("[ChromiumManager] Browser not available after ensureBrowser() — this should not happen");
       }
       const browser = state.browser;
-      context = await browser.newContext({
-        viewport: { width: 1280, height: 720 },
-        userAgent:
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Selene/1.0",
-        javaScriptEnabled: true,
-        ignoreHTTPSErrors: true,
-      });
+      context = await browser.newContext(createStandaloneContextOptions(viewport));
       page = await context.newPage();
     }
   } catch (err) {
@@ -556,18 +593,14 @@ export async function getOrCreateSession(sessionId: string): Promise<BrowserSess
     console.warn(`[ChromiumManager] Failed to create session context — restarting browser:`, err);
     await shutdownBrowser();
     await ensureBrowser();
+    viewport = requestedViewport;
 
     if (state.browserMode === "user-chrome" && state.persistentContext) {
       context = state.persistentContext;
       page = await context.newPage();
+      await applyBrowserViewportToPage(page, viewport);
     } else if (state.browser) {
-      context = await state.browser.newContext({
-        viewport: { width: 1280, height: 720 },
-        userAgent:
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Selene/1.0",
-        javaScriptEnabled: true,
-        ignoreHTTPSErrors: true,
-      });
+      context = await state.browser.newContext(createStandaloneContextOptions(viewport));
       page = await context.newPage();
     } else {
       throw new Error("[ChromiumManager] Browser restart failed — cannot create session");
@@ -580,6 +613,7 @@ export async function getOrCreateSession(sessionId: string): Promise<BrowserSess
     sessionId,
     context,
     page,
+    viewport,
     createdAt: now,
     lastAccessedAt: now,
   };
@@ -593,6 +627,19 @@ export async function getOrCreateSession(sessionId: string): Promise<BrowserSess
   });
 
   return session;
+}
+
+export async function setBrowserSessionViewport(
+  sessionId: string,
+  viewportInput: BrowserViewportInput
+): Promise<BrowserViewport> {
+  const session = await getOrCreateSession(sessionId);
+  session.lastAccessedAt = Date.now();
+  return applyViewportToSession(session, viewportInput);
+}
+
+export function getBrowserSessionViewport(sessionId: string): BrowserViewport | null {
+  return getState().sessions.get(sessionId)?.viewport ?? null;
 }
 
 /**

--- a/lib/browser/viewport.ts
+++ b/lib/browser/viewport.ts
@@ -1,0 +1,350 @@
+/**
+ * Browser viewport presets and resolver for Chromium workspace sessions.
+ *
+ * All dimensions are CSS viewport pixels. Device presets intentionally keep
+ * deviceScaleFactor at 1 so screenshots and screencast coordinate mapping stay
+ * deterministic while still exercising responsive layout breakpoints.
+ */
+
+import type { Page } from "playwright-core";
+
+export type BrowserViewportOrientation = "portrait" | "landscape";
+
+export interface BrowserViewportInput {
+  viewportPreset?: BrowserViewportPreset | string;
+  viewportWidth?: number;
+  viewportHeight?: number;
+  orientation?: BrowserViewportOrientation;
+  resetViewport?: boolean;
+}
+
+export interface BrowserViewportPresetDefinition {
+  label: string;
+  width: number;
+  height: number;
+  orientation: BrowserViewportOrientation;
+  category: "desktop" | "mobile" | "tablet";
+  isMobile: boolean;
+  hasTouch: boolean;
+  deviceScaleFactor: number;
+}
+
+export interface BrowserViewport {
+  width: number;
+  height: number;
+  orientation: BrowserViewportOrientation;
+  preset?: BrowserViewportPreset;
+  label: string;
+  category: "desktop" | "mobile" | "tablet" | "custom";
+  isMobile: boolean;
+  hasTouch: boolean;
+  deviceScaleFactor: number;
+  source: "default" | "preset" | "custom";
+}
+
+export const BROWSER_VIEWPORT_PRESETS = {
+  desktop: {
+    label: "Desktop 1280×720",
+    width: 1280,
+    height: 720,
+    orientation: "landscape",
+    category: "desktop",
+    isMobile: false,
+    hasTouch: false,
+    deviceScaleFactor: 1,
+  },
+  "desktop-wide": {
+    label: "Desktop Wide 1440×900",
+    width: 1440,
+    height: 900,
+    orientation: "landscape",
+    category: "desktop",
+    isMobile: false,
+    hasTouch: false,
+    deviceScaleFactor: 1,
+  },
+  mobile: {
+    label: "Mobile 390×844",
+    width: 390,
+    height: 844,
+    orientation: "portrait",
+    category: "mobile",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  "iphone-se": {
+    label: "iPhone SE 375×667",
+    width: 375,
+    height: 667,
+    orientation: "portrait",
+    category: "mobile",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  "iphone-14": {
+    label: "iPhone 14 390×844",
+    width: 390,
+    height: 844,
+    orientation: "portrait",
+    category: "mobile",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  "pixel-7": {
+    label: "Pixel 7 412×915",
+    width: 412,
+    height: 915,
+    orientation: "portrait",
+    category: "mobile",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  tablet: {
+    label: "Tablet 768×1024",
+    width: 768,
+    height: 1024,
+    orientation: "portrait",
+    category: "tablet",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  ipad: {
+    label: "iPad 768×1024",
+    width: 768,
+    height: 1024,
+    orientation: "portrait",
+    category: "tablet",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+  "ipad-pro": {
+    label: "iPad Pro 1024×1366",
+    width: 1024,
+    height: 1366,
+    orientation: "portrait",
+    category: "tablet",
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 1,
+  },
+} as const satisfies Record<string, BrowserViewportPresetDefinition>;
+
+export type BrowserViewportPreset = keyof typeof BROWSER_VIEWPORT_PRESETS;
+
+export const DEFAULT_BROWSER_VIEWPORT_PRESET: BrowserViewportPreset = "desktop";
+
+const VIEWPORT_MIN_PX = 100;
+const VIEWPORT_MAX_PX = 10_000;
+const VIEWPORT_MAX_AREA_PX = 25_000_000;
+
+export const DEFAULT_BROWSER_VIEWPORT: BrowserViewport = viewportFromPreset(
+  DEFAULT_BROWSER_VIEWPORT_PRESET,
+  "default"
+);
+
+export function isBrowserViewportPreset(value: unknown): value is BrowserViewportPreset {
+  return typeof value === "string" && value in BROWSER_VIEWPORT_PRESETS;
+}
+
+export function listBrowserViewportPresets(): BrowserViewportPreset[] {
+  return Object.keys(BROWSER_VIEWPORT_PRESETS) as BrowserViewportPreset[];
+}
+
+export function hasBrowserViewportInput(input: BrowserViewportInput | undefined): boolean {
+  if (!input) return false;
+  return (
+    input.resetViewport === true ||
+    input.viewportPreset != null ||
+    input.viewportWidth != null ||
+    input.viewportHeight != null ||
+    input.orientation != null
+  );
+}
+
+export function inferBrowserViewportOrientation(
+  width: number,
+  height: number
+): BrowserViewportOrientation {
+  return width > height ? "landscape" : "portrait";
+}
+
+export function resolveBrowserViewport(
+  input: BrowserViewportInput = {},
+  current: BrowserViewport = DEFAULT_BROWSER_VIEWPORT
+): BrowserViewport {
+  if (input.resetViewport === true) {
+    return { ...DEFAULT_BROWSER_VIEWPORT };
+  }
+
+  const requestedPreset = input.viewportPreset == null
+    ? undefined
+    : resolvePreset(input.viewportPreset);
+  const requestedOrientation = resolveViewportOrientation(input.orientation);
+
+  const base = requestedPreset ? viewportFromPreset(requestedPreset, "preset") : current;
+  const customWidth = coerceViewportDimension(input.viewportWidth, "viewportWidth");
+  const customHeight = coerceViewportDimension(input.viewportHeight, "viewportHeight");
+  const hasCustomDimensions = customWidth != null || customHeight != null;
+
+  let width = customWidth ?? base.width;
+  let height = customHeight ?? base.height;
+  const orientation = requestedOrientation ?? inferBrowserViewportOrientation(width, height);
+
+  if (orientation === "portrait" && width > height) {
+    [width, height] = [height, width];
+  } else if (orientation === "landscape" && height > width) {
+    [width, height] = [height, width];
+  }
+
+  assertViewportArea(width, height);
+
+  const category: BrowserViewport["category"] = hasCustomDimensions ? "custom" : base.category;
+  const source: BrowserViewport["source"] = hasCustomDimensions
+    ? "custom"
+    : requestedPreset
+      ? "preset"
+      : requestedOrientation != null && base.source === "default"
+        ? "custom"
+        : base.source;
+  const preset = hasCustomDimensions ? undefined : base.preset;
+  const label = hasCustomDimensions || width !== base.width || height !== base.height
+    ? formatBrowserViewportLabel(width, height, category)
+    : base.label;
+
+  return {
+    width,
+    height,
+    orientation,
+    preset,
+    label,
+    category,
+    isMobile: base.isMobile,
+    hasTouch: base.hasTouch,
+    deviceScaleFactor: base.deviceScaleFactor,
+    source,
+  };
+}
+
+export function browserViewportToContextOptions(viewport: BrowserViewport) {
+  return {
+    viewport: { width: viewport.width, height: viewport.height },
+    deviceScaleFactor: viewport.deviceScaleFactor,
+    isMobile: viewport.isMobile,
+    hasTouch: viewport.hasTouch,
+  };
+}
+
+export function formatBrowserViewport(viewport: BrowserViewport): string {
+  return `${viewport.label} (${viewport.width}×${viewport.height}, ${viewport.orientation})`;
+}
+
+export async function applyBrowserViewportToPage(
+  page: Page,
+  viewport: BrowserViewport
+): Promise<void> {
+  const viewportSize = { width: viewport.width, height: viewport.height };
+
+  if (!viewport.isMobile && !viewport.hasTouch && viewport.deviceScaleFactor === 1) {
+    const cdp = await page.context().newCDPSession(page);
+    try {
+      await cdp.send("Emulation.clearDeviceMetricsOverride").catch(() => {});
+      await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: false }).catch(() => {});
+    } finally {
+      await cdp.detach().catch(() => {});
+    }
+    await page.setViewportSize(viewportSize);
+    return;
+  }
+
+  await page.setViewportSize(viewportSize);
+
+  const cdp = await page.context().newCDPSession(page);
+  try {
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: viewport.width,
+      height: viewport.height,
+      deviceScaleFactor: viewport.deviceScaleFactor,
+      mobile: viewport.isMobile,
+      screenWidth: viewport.width,
+      screenHeight: viewport.height,
+      screenOrientation: {
+        type: viewport.orientation === "landscape" ? "landscapePrimary" : "portraitPrimary",
+        angle: viewport.orientation === "landscape" ? 90 : 0,
+      },
+    });
+    await cdp.send("Emulation.setTouchEmulationEnabled", {
+      enabled: viewport.hasTouch,
+      maxTouchPoints: viewport.hasTouch ? 5 : 0,
+    });
+  } finally {
+    await cdp.detach().catch(() => {});
+  }
+}
+
+function viewportFromPreset(
+  preset: BrowserViewportPreset,
+  source: BrowserViewport["source"]
+): BrowserViewport {
+  const definition = BROWSER_VIEWPORT_PRESETS[preset];
+  return {
+    width: definition.width,
+    height: definition.height,
+    orientation: definition.orientation,
+    preset,
+    label: definition.label,
+    category: definition.category,
+    isMobile: definition.isMobile,
+    hasTouch: definition.hasTouch,
+    deviceScaleFactor: definition.deviceScaleFactor,
+    source,
+  };
+}
+
+function resolvePreset(value: BrowserViewportPreset | string): BrowserViewportPreset {
+  if (isBrowserViewportPreset(value)) return value;
+  throw new Error(
+    `Unknown viewport preset "${value}". Available presets: ${listBrowserViewportPresets().join(", ")}`
+  );
+}
+
+function resolveViewportOrientation(value: unknown): BrowserViewportOrientation | undefined {
+  if (value == null) return undefined;
+  if (value === "portrait" || value === "landscape") return value;
+  throw new Error('orientation must be "portrait" or "landscape"');
+}
+
+function assertViewportArea(width: number, height: number): void {
+  const area = width * height;
+  if (area > VIEWPORT_MAX_AREA_PX) {
+    throw new Error(`Viewport area must be at most ${VIEWPORT_MAX_AREA_PX} CSS pixels`);
+  }
+}
+
+function coerceViewportDimension(value: unknown, fieldName: string): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldName} must be a finite number`);
+  }
+
+  const rounded = Math.round(value);
+  if (rounded < VIEWPORT_MIN_PX || rounded > VIEWPORT_MAX_PX) {
+    throw new Error(`${fieldName} must be between ${VIEWPORT_MIN_PX} and ${VIEWPORT_MAX_PX} pixels`);
+  }
+
+  return rounded;
+}
+
+function formatBrowserViewportLabel(
+  width: number,
+  height: number,
+  category: BrowserViewport["category"]
+): string {
+  const prefix = category === "custom" ? "Custom" : category.charAt(0).toUpperCase() + category.slice(1);
+  return `${prefix} ${width}×${height}`;
+}

--- a/scripts/validation/validate-chromium-workspace.ts
+++ b/scripts/validation/validate-chromium-workspace.ts
@@ -124,8 +124,20 @@ async function runDryRunTests(): Promise<void> {
   assert(typeof toolInstance === "object", "Tool instance is created");
   assert("execute" in toolInstance, "Tool has execute method");
 
-  // Test 7: Output matching for replay verification
-  section("7. Output Matching");
+  // Test 7: Viewport resolver
+  section("7. Viewport Resolver");
+  const { resolveBrowserViewport, DEFAULT_BROWSER_VIEWPORT } = await import("../../lib/browser/viewport");
+  const mobile = resolveBrowserViewport({ viewportPreset: "mobile" });
+  assert(mobile.width < mobile.height && mobile.isMobile, "Mobile preset resolves to portrait touch viewport");
+  const tabletLandscape = resolveBrowserViewport({ viewportPreset: "tablet", orientation: "landscape" });
+  assert(tabletLandscape.width === 1024 && tabletLandscape.height === 768, "Tablet landscape orientation is respected");
+  const custom = resolveBrowserViewport({ viewportWidth: 1024, viewportHeight: 768 });
+  assert(custom.width === 1024 && custom.height === 768, "Custom dimensions are resolved");
+  const reset = resolveBrowserViewport({ resetViewport: true }, mobile);
+  assert(reset.width === DEFAULT_BROWSER_VIEWPORT.width && reset.height === DEFAULT_BROWSER_VIEWPORT.height, "Reset restores default desktop viewport");
+
+  // Test 8: Output matching for replay verification
+  section("8. Output Matching");
   assert(typeof history.outputsMatch === "function", "outputsMatch is exported");
   assert(history.outputsMatch("hello", "hello") === true, "Identical strings match");
   assert(history.outputsMatch({ a: 1 }, { a: 1 }) === true, "Identical objects match");
@@ -133,8 +145,8 @@ async function runDryRunTests(): Promise<void> {
   assert(history.outputsMatch(null, null) === true, "Null values match");
   assert(history.outputsMatch(null, undefined) === true, "Null and undefined match");
 
-  // Test 8: Replay plan includes expected output
-  section("8. Replay Plan Expected Outputs");
+  // Test 9: Replay plan includes expected output
+  section("9. Replay Plan Expected Outputs");
   assert("expectedOutput" in replayPlan[0], "Replay plan includes expectedOutput field");
 }
 
@@ -153,6 +165,7 @@ async function runLiveTests(): Promise<void> {
     shutdownAll,
   } = await import("../../lib/browser/session-manager");
   const { initHistory, finalizeHistory } = await import("../../lib/browser/action-history");
+  const { executeAction } = await import("../../lib/ai/tools/chromium-workspace-tool");
 
   // Test 1: Create concurrent sessions
   section("1. Concurrent Session Creation");
@@ -219,8 +232,51 @@ async function runLiveTests(): Promise<void> {
   await recreatedB.page.goto("https://example.com", { waitUntil: "domcontentloaded" });
   assert(recreatedB.page.url().includes("example.com"), "Recreated session can navigate successfully");
 
-  // Test 6: Shutdown all
-  section("6. Full Shutdown");
+  // Test 6: Responsive viewport controls
+  section("6. Responsive Viewport Controls");
+  const viewportSessionId = "live-viewport";
+  const viewportUrl = `data:text/html,${encodeURIComponent(
+    '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>viewport test</body></html>'
+  )}`;
+  const readViewport = async () => {
+    const result = await executeAction(viewportSessionId, {
+      action: "evaluate",
+      expression: "({ width: window.innerWidth, height: window.innerHeight, screenWidth: screen.width, screenHeight: screen.height })",
+    }, 30_000);
+    return JSON.parse(String(result.data)) as { width: number; height: number; screenWidth: number; screenHeight: number };
+  };
+
+  await executeAction(viewportSessionId, {
+    action: "open",
+    url: viewportUrl,
+    viewportPreset: "mobile",
+    orientation: "portrait",
+  }, 30_000);
+  let dims = await readViewport();
+  assert(dims.width === 390 && dims.height === 844, "Mobile portrait viewport is applied before open/navigation");
+
+  await executeAction(viewportSessionId, {
+    action: "setViewport",
+    viewportPreset: "tablet",
+    orientation: "landscape",
+  }, 30_000);
+  dims = await readViewport();
+  assert(dims.width === 1024 && dims.height === 768, "Tablet landscape viewport is applied");
+
+  await executeAction(viewportSessionId, {
+    action: "setViewport",
+    viewportWidth: 901,
+    viewportHeight: 701,
+  }, 30_000);
+  dims = await readViewport();
+  assert(dims.width === 901 && dims.height === 701, "Custom viewport dimensions are applied");
+
+  await executeAction(viewportSessionId, { action: "resetViewport" }, 30_000);
+  dims = await readViewport();
+  assert(dims.width === 1280 && dims.height === 720, "Reset restores the default desktop viewport");
+
+  // Test 7: Shutdown all
+  section("7. Full Shutdown");
   await shutdownAll();
   assert(getActiveSessionCount() === 0, "All sessions closed");
 

--- a/tests/components/chat-provider.sanitize.test.ts
+++ b/tests/components/chat-provider.sanitize.test.ts
@@ -132,11 +132,17 @@ describe("sanitizeMessagesForInit", () => {
             type: "tool-chromiumWorkspace",
             toolCallId: "tool-browser",
             state: "input-available",
-            input: { action: "open", url: "https://example.com" },
+            input: {
+              action: "open",
+              url: "https://example.com",
+              viewportPreset: "mobile",
+              orientation: "portrait",
+            },
             output: {
               status: "success",
               data: "Browser session opened. Navigated to: https://example.com",
               pageUrl: "https://example.com",
+              viewport: { width: 390, height: 844, orientation: "portrait", preset: "mobile" },
             },
           },
         ],
@@ -152,10 +158,17 @@ describe("sanitizeMessagesForInit", () => {
     );
 
     expect(browserPart).toBeDefined();
+    expect((browserPart as any).input).toEqual({
+      action: "open",
+      url: "https://example.com",
+      viewportPreset: "mobile",
+      orientation: "portrait",
+    });
     expect((browserPart as any).output).toEqual({
       status: "success",
       data: "Browser session opened. Navigated to: https://example.com",
       pageUrl: "https://example.com",
+      viewport: { width: 390, height: 844, orientation: "portrait", preset: "mobile" },
     });
   });
 

--- a/tests/lib/browser/action-history.test.ts
+++ b/tests/lib/browser/action-history.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  finalizeHistory,
+  initHistory,
+  peekHistory,
+  recordAction,
+} from "@/lib/browser/action-history";
+import { DEFAULT_BROWSER_VIEWPORT } from "@/lib/browser/viewport";
+
+describe("browser action history", () => {
+  it("persists the resolved viewport with recorded actions", () => {
+    const sessionId = `viewport-history-${Date.now()}-${Math.random()}`;
+
+    initHistory(sessionId);
+    recordAction(sessionId, "snapshot", { action: "snapshot" }, {
+      success: true,
+      durationMs: 12,
+      output: "snapshot output",
+      viewport: DEFAULT_BROWSER_VIEWPORT,
+    });
+
+    const peeked = peekHistory(sessionId);
+    expect(peeked?.actions[0].viewport).toEqual(DEFAULT_BROWSER_VIEWPORT);
+
+    const finalized = finalizeHistory(sessionId);
+    expect(finalized?.actions[0].viewport).toEqual(DEFAULT_BROWSER_VIEWPORT);
+  });
+});

--- a/tests/lib/browser/viewport.test.ts
+++ b/tests/lib/browser/viewport.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_BROWSER_VIEWPORT,
+  resolveBrowserViewport,
+} from "@/lib/browser/viewport";
+
+describe("Chromium browser viewport resolver", () => {
+  it("resolves a mobile preset in portrait orientation", () => {
+    const viewport = resolveBrowserViewport({ viewportPreset: "mobile" });
+
+    expect(viewport.preset).toBe("mobile");
+    expect(viewport.category).toBe("mobile");
+    expect(viewport.orientation).toBe("portrait");
+    expect(viewport.width).toBeLessThan(viewport.height);
+    expect(viewport.isMobile).toBe(true);
+    expect(viewport.hasTouch).toBe(true);
+  });
+
+  it("resolves a tablet preset in landscape orientation", () => {
+    const viewport = resolveBrowserViewport({
+      viewportPreset: "tablet",
+      orientation: "landscape",
+    });
+
+    expect(viewport.preset).toBe("tablet");
+    expect(viewport.category).toBe("tablet");
+    expect(viewport.orientation).toBe("landscape");
+    expect(viewport.width).toBe(1024);
+    expect(viewport.height).toBe(768);
+    expect(viewport.width).toBeGreaterThan(viewport.height);
+  });
+
+  it("resolves custom dimensions", () => {
+    const viewport = resolveBrowserViewport({
+      viewportWidth: 1024,
+      viewportHeight: 768,
+    });
+
+    expect(viewport.category).toBe("custom");
+    expect(viewport.source).toBe("custom");
+    expect(viewport.width).toBe(1024);
+    expect(viewport.height).toBe(768);
+    expect(viewport.orientation).toBe("landscape");
+  });
+
+  it("respects portrait orientation for custom dimensions by swapping dimensions", () => {
+    const viewport = resolveBrowserViewport({
+      viewportWidth: 1000,
+      viewportHeight: 600,
+      orientation: "portrait",
+    });
+
+    expect(viewport.width).toBe(600);
+    expect(viewport.height).toBe(1000);
+    expect(viewport.orientation).toBe("portrait");
+  });
+
+  it("treats preset plus custom dimensions as custom dimensions with preset emulation traits", () => {
+    const viewport = resolveBrowserViewport({
+      viewportPreset: "mobile",
+      viewportWidth: 500,
+      viewportHeight: 900,
+    });
+
+    expect(viewport.preset).toBeUndefined();
+    expect(viewport.category).toBe("custom");
+    expect(viewport.source).toBe("custom");
+    expect(viewport.width).toBe(500);
+    expect(viewport.height).toBe(900);
+    expect(viewport.isMobile).toBe(true);
+    expect(viewport.hasTouch).toBe(true);
+  });
+
+  it("preserves preset identity for orientation-only updates", () => {
+    const current = resolveBrowserViewport({ viewportPreset: "mobile" });
+    const viewport = resolveBrowserViewport({ orientation: "landscape" }, current);
+
+    expect(viewport.preset).toBe("mobile");
+    expect(viewport.category).toBe("mobile");
+    expect(viewport.source).toBe("preset");
+    expect(viewport.orientation).toBe("landscape");
+    expect(viewport.width).toBe(844);
+    expect(viewport.height).toBe(390);
+  });
+
+  it("preserves mobile emulation traits when custom dimensions are based on a mobile viewport", () => {
+    const current = resolveBrowserViewport({ viewportPreset: "mobile" });
+    const viewport = resolveBrowserViewport({ viewportWidth: 480, viewportHeight: 800 }, current);
+
+    expect(viewport.preset).toBeUndefined();
+    expect(viewport.category).toBe("custom");
+    expect(viewport.source).toBe("custom");
+    expect(viewport.isMobile).toBe(true);
+    expect(viewport.hasTouch).toBe(true);
+  });
+
+  it("resets back to the default desktop viewport", () => {
+    const current = resolveBrowserViewport({ viewportPreset: "mobile" });
+    const viewport = resolveBrowserViewport({ resetViewport: true }, current);
+
+    expect(viewport).toEqual(DEFAULT_BROWSER_VIEWPORT);
+    expect(viewport.width).toBe(1280);
+    expect(viewport.height).toBe(720);
+    expect(viewport.orientation).toBe("landscape");
+  });
+
+  it("lets reset win over conflicting viewport inputs", () => {
+    const current = resolveBrowserViewport({ viewportPreset: "mobile" });
+    const viewport = resolveBrowserViewport({
+      resetViewport: true,
+      viewportPreset: "tablet",
+      viewportWidth: 500,
+      viewportHeight: 900,
+      orientation: "portrait",
+    }, current);
+
+    expect(viewport).toEqual(DEFAULT_BROWSER_VIEWPORT);
+  });
+
+  it("rejects invalid runtime orientation values", () => {
+    expect(() => resolveBrowserViewport({ orientation: "sideways" } as never)).toThrow(
+      'orientation must be "portrait" or "landscape"'
+    );
+  });
+
+  it("rejects viewport areas that are too large", () => {
+    expect(() => resolveBrowserViewport({
+      viewportWidth: 6000,
+      viewportHeight: 6000,
+    })).toThrow("Viewport area must be at most");
+  });
+
+  it("rejects unknown presets instead of guessing", () => {
+    expect(() => resolveBrowserViewport({ viewportPreset: "watch" })).toThrow(
+      "Unknown viewport preset"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add centralized Chromium browser viewport presets/resolver with mobile/tablet/custom/reset support.
- Apply resolved viewport before Chromium workspace actions and expose viewport controls in tool schema/results/UI.
- Preserve viewport metadata through action history, SSE action events, replay, and chat tool-part sanitization.
- Harden resolver/replay edge cases with runtime orientation validation, viewport area cap, replay action precedence, and replay-session history recording.

## Validation
- `npm exec vitest -- run tests/lib/browser/viewport.test.ts tests/lib/browser/action-history.test.ts tests/components/chat-provider.sanitize.test.ts` — 20 passed
- `npm run test:validate:chromium-workspace:dry` — 36 passed, 0 failed
- `npm run typecheck` — 4 passed, 0 failed
- `npm run test:validate:chromium-workspace` — live real-browser validation passed earlier on the same final tree